### PR TITLE
Compatibility with pandas 1

### DIFF
--- a/src/chemcoord/cartesian_coordinates/_cartesian_class_io.py
+++ b/src/chemcoord/cartesian_coordinates/_cartesian_class_io.py
@@ -174,6 +174,33 @@ class CartesianIO(CartesianCore, GenericIO):
             molecule.get_bonds(use_lookup=False, set_lookup=True)
         return molecule
 
+    @classmethod
+    def read_string(cls, xyz_string, start_index=0, get_bonds=True,
+                    nrows=None, engine=None):
+        """Read a string of coordinate information.
+
+        Reads xyz-strings.
+
+        Args:
+            xyz_string (str):
+            start_index (int):
+            get_bonds (bool):
+            nrows (int): Number of rows of file to read.
+                Note that the first two rows are implicitly excluded.
+            engine (str): Wrapper for argument of :func:`pandas.read_csv`.
+
+        Returns:
+            Cartesian:
+        """
+        import sys
+        if sys.version_info[0] < 3:  # I read the import depends on the sys version
+            from StringIO import StringIO
+        else:
+            from io import StringIO
+        buf = StringIO(xyz_string)
+        molecule = cls.read_xyz(buf, start_index=start_index, get_bonds=get_bonds, nrows=nrows, engine=engine)
+        return molecule
+
     def to_cjson(self, buf=None, **kwargs):
         """Write a cjson file or return dictionary.
 

--- a/src/chemcoord/cartesian_coordinates/_cartesian_class_pandas_wrapper.py
+++ b/src/chemcoord/cartesian_coordinates/_cartesian_class_pandas_wrapper.py
@@ -173,7 +173,7 @@ class PandasWrapper(object):
 
     def sort_index(self, axis=0, level=None, ascending=True, inplace=False,
                    kind='quicksort', na_position='last',
-                   sort_remaining=True, by=None):
+                   sort_remaining=True):
         """Sort object by labels (along an axis)
 
         Wrapper around the :meth:`pandas.DataFrame.sort_index` method.
@@ -182,12 +182,12 @@ class PandasWrapper(object):
             self._frame.sort_index(
                 axis=axis, level=level, ascending=ascending, inplace=inplace,
                 kind=kind, na_position=na_position,
-                sort_remaining=sort_remaining, by=by)
+                sort_remaining=sort_remaining)
         else:
             new = self.__class__(self._frame.sort_index(
                 axis=axis, level=level, ascending=ascending,
                 inplace=inplace, kind=kind, na_position=na_position,
-                sort_remaining=sort_remaining, by=by))
+                sort_remaining=sort_remaining))
             new.metadata = self.metadata.copy()
             new._metadata = copy.deepcopy(self._metadata)
             return new

--- a/src/chemcoord/cartesian_coordinates/xyz_functions.py
+++ b/src/chemcoord/cartesian_coordinates/xyz_functions.py
@@ -467,6 +467,8 @@ def apply_grad_zmat_tensor(grad_C, construction_table, cart_dist):
     if C_dist.dtype == np.dtype('i8'):
         C_dist = C_dist.astype('f8')
     try:
+        C_dist = C_dist.float()  # Don't fully get why but otherwise I get error in test (probably version dependent, see below)
+        # "TypeError: loop of ufunc does not support argument 0 of type Zero which has no callable rad2deg method"
         C_dist[:, [1, 2]] = np.rad2deg(C_dist[:, [1, 2]])
     except AttributeError:
         C_dist[:, [1, 2]] = sympy.deg(C_dist[:, [1, 2]])

--- a/src/chemcoord/internal_coordinates/_zmat_class_pandas_wrapper.py
+++ b/src/chemcoord/internal_coordinates/_zmat_class_pandas_wrapper.py
@@ -72,7 +72,7 @@ class PandasWrapper(object):
 
     def sort_index(self, axis=0, level=None, ascending=True, inplace=False,
                    kind='quicksort', na_position='last',
-                   sort_remaining=True, by=None):
+                   sort_remaining=True):
         """Sort object by labels (along an axis)
 
         Wrapper around the :meth:`pandas.DataFrame.sort_index` method.
@@ -80,7 +80,7 @@ class PandasWrapper(object):
         return self._frame.sort_index(axis=axis, level=level,
                                       ascending=ascending, inplace=inplace,
                                       kind=kind, na_position=na_position,
-                                      sort_remaining=sort_remaining, by=by)
+                                      sort_remaining=sort_remaining)
 
     def insert(self, loc, column, value, allow_duplicates=False,
                inplace=False):

--- a/tests/cartesian_coordinates/Cartesian/test_io.py
+++ b/tests/cartesian_coordinates/Cartesian/test_io.py
@@ -47,17 +47,17 @@ def test_to_string():
                 '6    H  3.260455  0.5 -0.872893')
     assert molecule.to_string() == expected
 
-
 def test_to_xyz():
-    expected = """6
+    base = """6
 Created by chemcoord http://chemcoord.readthedocs.io/
-O 0.000000 0.000000  0.000000
-H 0.758602 0.000000  0.504284
-H 0.260455 0.000000 -0.872893
-O 3.000000 0.500000  0.000000
-H 3.758602 0.500000  0.504284
-H 3.260455 0.500000 -0.872893"""
-    assert molecule.to_xyz() == expected
+{}O 0.000000 0.000000  0.000000
+{}H 0.758602 0.000000  0.504284
+{}H 0.260455 0.000000 -0.872893
+{}O 3.000000 0.500000  0.000000
+{}H 3.758602 0.500000  0.504284
+{}H 3.260455 0.500000 -0.872893"""
+    expected = [base.format(*6*[i]) for i in [""," "]]  # accepts both initial whitespace or not
+    assert molecule.to_xyz() in expected
 
     with pytest.warns(DeprecationWarning):
-        assert molecule.write_xyz() == expected
+        assert molecule.write_xyz() in expected

--- a/tests/cartesian_coordinates/Cartesian/test_pandas_wrapper.py
+++ b/tests/cartesian_coordinates/Cartesian/test_pandas_wrapper.py
@@ -49,15 +49,16 @@ def test_to_string():
 
 
 def test_to_xyz():
-    expected = """6
+    base = """6
 Created by chemcoord http://chemcoord.readthedocs.io/
-O 0.000000 0.000000  0.000000
-H 0.758602 0.000000  0.504284
-H 0.260455 0.000000 -0.872893
-O 3.000000 0.500000  0.000000
-H 3.758602 0.500000  0.504284
-H 3.260455 0.500000 -0.872893"""
-    assert molecule.to_xyz() == expected
+{}O 0.000000 0.000000  0.000000
+{}H 0.758602 0.000000  0.504284
+{}H 0.260455 0.000000 -0.872893
+{}O 3.000000 0.500000  0.000000
+{}H 3.758602 0.500000  0.504284
+{}H 3.260455 0.500000 -0.872893"""
+    expected = [base.format(*6*[i]) for i in [""," "]]  # accepts both initial whitespace or not
+    assert molecule.to_xyz() in expected
 
     with pytest.warns(DeprecationWarning):
-        assert molecule.write_xyz() == expected
+        assert molecule.write_xyz() in expected


### PR DESCRIPTION
Dear Oskar Weser,
I have:
1. a) removed the "by" from pd.sort_index(..., sort_remaining=by). One could check the pd version and based on that call the function differently, but I deem it superfluous as "by" was always left equal to "None" (at least as far as I saw).
b) This functions is called by "zmat.get_cartesian()" which is already tested, so no additional test is needed
2. some tests were failing because of leading spaces (e.g. " O 0.0 0.0 0.0" instead of "O 0.0 0.0 0.0"). I think this also depends on package versions and the test should accept both. I creat both versions and assert the result matches either.
3. I propose (feel free to discard) a cartesian.read_string() for users that may not be familiar with StringIO. 

Best, NR
