### PR TITLE
Fix character set issues with README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ chemcoord: A python module for coordinates of molecules
 Website
 -------
 
-The project’s website with documentation is:
+The project's website with documentation is:
 http://chemcoord.readthedocs.org/
 
 Features
@@ -40,8 +40,8 @@ Features
    redundant internal coordinates (Zmatrices). Dummy atoms are inserted
    and removed automatically on the fly if necessary.
 -  The created Zmatrix is not only a structure expressed in internal
-   coordinates, it is a “chemical” Zmatrix. “Chemical” Zmatrix means,
-   that e.g. distances are along bonds or dihedrals are defined as they
+   coordinates, it is a "chemical" Zmatrix. "Chemical" Zmatrix means,
+   that e.g. distances are along bonds or dihedrals are defined as they
    are drawn in chemical textbooks (Newman projections).
 -  Analytical gradients for the transformations between the different
    coordinate systems are implemented.


### PR DESCRIPTION
Running conda-forge build on Windows had character set issues for some reason.

I narrowed down the offending character and it seems to build on Windows now.

https://github.com/conda-forge/staged-recipes/pull/23047