### PR TITLE
Replace numba generated jit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ shared: &shared
           command: pip3 install pytest pytest-cov
       - run:
           name: Running tests
-          command: python3 -m pytest --cov=./src/chemcoord tests/
+          command: python3 -m pytest -Werror --cov=./src/chemcoord tests/
       - run:
           name: Upload coverage reports to Codecov
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ workflows:
     jobs:
       - py38
       - py39
+      - py310
 
 jobs:
   py38:
@@ -34,4 +35,9 @@ jobs:
     <<: *shared
     docker:
       - image: cimg/python:3.9
+
+  py310:
+    <<: *shared
+    docker:
+      - image: cimg/python:3.10
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,11 +21,18 @@ shared: &shared
 workflows:
   sample:
     jobs:
+      - py37
       - py38
       - py39
       - py310
+      - py311
 
 jobs:
+  py37:
+    <<: *shared
+    docker:
+      - image: cimg/python:3.7
+
   py38:
     <<: *shared
     docker:
@@ -41,3 +48,7 @@ jobs:
     docker:
       - image: cimg/python:3.10
 
+  py311:
+    <<: *shared
+    docker:
+      - image: cimg/python:3.11

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,5 +17,6 @@ sphinx:
 
 python:
   install:
-    - method: pip
-      path: .
+    # - method: pip
+    #   path: .
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,6 @@ sphinx:
 
 python:
   install:
-    # - method: pip
-    #   path: .
+    - method: pip
+      path: .
     - requirements: docs/requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Features
 Installation guide
 ------------------
 
-A working python 3 installation is required (>=3.7 are possible).
+A working python 3 installation is required (3.7 <= version <= 3.11 are tested).
 
 It is highly recommended to use this module in combination with
 `Ipython <http://ipython.org/>`__ and `jupyter <http://jupyter.org/>`__.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,4 @@ six
 pymatgen
 scipy>=1.0
 pytest
+sphinx-rtd-theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,1 @@
-numpy>=1.21
-pandas>=1.0
-numba>=0.35
-sortedcontainers
-sympy
-six
-pymatgen
-scipy>=1.0
-pytest
 sphinx-rtd-theme

--- a/docs/source/bugs_and_contributors.rst
+++ b/docs/source/bugs_and_contributors.rst
@@ -11,6 +11,8 @@ Previous Contribution
 
 * Main Work: Oskar Weser
 
+* Scientific supervision: `Ricardo Mata <https://www.uni-goettingen.de/en/123801.html>`__
+
 * Python2 compatibility: Keld Lundgaard
 
 * Maintenance (Change in pandas API): Niccolo Ricardi

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,7 +40,7 @@ Contents
     tutorial.rst
     documentation.rst
     references.rst
-    bugs.rst
+    bugs_and_contributors.rst
     license.rst
 
 
@@ -50,17 +50,38 @@ The changelog can be found
 Citation and mathematical background
 ++++++++++++++++++++++++++++++++++++
 
-If chemcoord is used in a project that leads to a scientific publication,
-please acknowledge this fact by citing Oskar Weser (2017) using this ready-made BibTeX entry::
+
+The theory behind chemcoord is described in `this paper <https://onlinelibrary.wiley.com/doi/full/10.1002/jcc.27029>`__.
+If this package is used in a project that leads to a scientific
+publication, please acknowledge it by citing.
+
+::
+
+    @article{https://doi.org/10.1002/jcc.27029,
+        author = {Weser, Oskar and Hein-Janke, Björn and Mata, Ricardo A.},
+        title = {Automated handling of complex chemical structures in Z-matrix coordinates—The chemcoord library},
+        journal = {Journal of Computational Chemistry},
+        volume = {44},
+        number = {5},
+        pages = {710-726},
+        keywords = {analytical gradients, geometry optimization, non-linear constraints, transition state search, Z-matrix},
+        doi = {10.1002/jcc.27029},
+        year = {2023}
+    }
+
+
+My (Oskar Weser) master thesis including a more detailed derivation of implemented equations and
+the mathematical background can be found
+`here <https://github.com/mcocdawc/chemcoord/blob/master/docs/source/files/master_thesis_oskar_weser_chemcoord.pdf>`__.
+It also has a ready-made BibTeX entry:
+
+::
 
   @mastersthesis{OWeser2017,
-  author = {Oskar Weser},
-  title = {An efficient and general library for the definition and use of internal coordinates in large molecular systems},
-  school = {Georg August Universität Göttingen},
-  year = {2017},
-  month = {November},
+      author = {Oskar Weser},
+      title = {An efficient and general library for the definition and use of internal coordinates in large molecular systems},
+      school = {Georg August Universität Göttingen},
+      year = {2017},
+      month = {November},
   }
 
-The master thesis including the derivation of implemented equations
-and the mathematical background can be found
-`here <https://github.com/mcocdawc/chemcoord/blob/master/docs/source/files/master_thesis_oskar_weser_chemcoord.pdf>`_.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,6 +1,6 @@
 Installation guide
 ==================
-A working python 3 installation is required (versions >=3.7 are possible).
+A working python 3 installation is required (3.7 <= version <= 3.11 are tested).
 
 It is highly recommended to use this module in combination with
 `Ipython <http://ipython.org/>`_ and `jupyter <http://jupyter.org/>`_.

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering :: Chemistry',
     'Topic :: Scientific/Engineering :: Physics']
 VERSION = '2.1.0'

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
     'Topic :: Scientific/Engineering :: Chemistry',
     'Topic :: Scientific/Engineering :: Physics']
 VERSION = '2.1.0'

--- a/src/chemcoord/cartesian_coordinates/_cart_transformation.py
+++ b/src/chemcoord/cartesian_coordinates/_cart_transformation.py
@@ -2,8 +2,9 @@
 import warnings
 
 import numba as nb
+from numba import jit
 from numba.core.errors import NumbaDeprecationWarning
-from numba import jit, generated_jit
+from numba.extending import overload
 import numpy as np
 from numpy import arccos, arctan2, sqrt
 
@@ -14,31 +15,39 @@ from chemcoord.cartesian_coordinates.xyz_functions import (_jit_cross,
 from chemcoord.exceptions import ERR_CODE_OK, ERR_CODE_InvalidReference
 
 
-with warnings.catch_warnings():
-    # This has to be fixed in the near-future
-    # https://github.com/mcocdawc/chemcoord/issues/76
-    warnings.simplefilter("ignore", category=NumbaDeprecationWarning)
-    @generated_jit(nopython=True)
-    def get_ref_pos(X, indices):  # pylint:disable=unused-argument
-        if isinstance(indices, nb.types.Array):
-            def f(X, indices):
-                ref_pos = np.empty((3, len(indices)))
-                for col, i in enumerate(indices):
-                    if i < constants.keys_below_are_abs_refs:
-                        ref_pos[:, col] = constants._jit_absolute_refs(i)
-                    else:
-                        ref_pos[:, col] = X[:, i]
-                return ref_pos
-            return f
-        elif isinstance(indices, nb.types.Integer):
-            def f(X, indices):
-                i = indices
+
+def _stub_get_ref_pos(X, indices):  # pylint:disable=unused-argument
+    raise AssertionError("Should not call this function unjitted.")
+
+
+@overload(_stub_get_ref_pos)
+def _get_ref_pos_impl(X, indices):  # pylint:disable=unused-argument
+    if isinstance(indices, nb.types.Array):
+        def f(X, indices):
+            ref_pos = np.empty((3, len(indices)))
+            for col, i in enumerate(indices):
                 if i < constants.keys_below_are_abs_refs:
-                    ref_pos = constants._jit_absolute_refs(i)
+                    ref_pos[:, col] = constants._jit_absolute_refs(i)
                 else:
-                    ref_pos = X[:, i]
-                return ref_pos
-            return f
+                    ref_pos[:, col] = X[:, i]
+            return ref_pos
+        return f
+    elif isinstance(indices, nb.types.Integer):
+        def f(X, indices):
+            i = indices
+            if i < constants.keys_below_are_abs_refs:
+                ref_pos = constants._jit_absolute_refs(i)
+            else:
+                ref_pos = X[:, i]
+            return ref_pos
+        return f
+    else:
+        raise AssertionError("Should not be here")
+
+
+@jit(nopython=True, cache=True)
+def get_ref_pos(X, indices):
+    return _stub_get_ref_pos(X, indices)
 
 
 @jit(nopython=True, cache=True)

--- a/src/chemcoord/cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/cartesian_coordinates/_cartesian_class_core.py
@@ -281,7 +281,7 @@ class CartesianCore(PandasWrapper, GenericCore):
             if out.loc[:, col].dtype is np.dtype('O'):
                 out.loc[:, col] = out.loc[:, col].map(get_subs_f(*args))
                 try:
-                    out.loc[:, col] = out.loc[:, col].astype('f8')
+                    out._frame = out._frame.astype({col: 'f8'})
                 except (SystemError, TypeError):
                     pass
         return out

--- a/src/chemcoord/cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/cartesian_coordinates/_cartesian_class_core.py
@@ -95,7 +95,7 @@ class CartesianCore(PandasWrapper, GenericCore):
 
     def _test_if_can_be_added(self, other):
         if not (set(self.index) == set(other.index)
-                and np.alltrue(self['atom'] == other.loc[self.index, 'atom'])):
+                and (self['atom'] == other.loc[self.index, 'atom']).all(axis=None)):
             message = ("You can add only Cartesians which are indexed in the "
                        "same way and use the same atoms.")
             raise PhysicalMeaning(message)

--- a/src/chemcoord/cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/cartesian_coordinates/_cartesian_class_core.py
@@ -56,8 +56,8 @@ class CartesianCore(PandasWrapper, GenericCore):
             message = 'Either frame or atoms and coords have to be not None'
             raise IllegalArgumentCombination(message)
         elif atoms is not None and coords is not None:
-            frame = pd.DataFrame(index=index,
-                                 columns=['atom', 'x', 'y', 'z'], dtype='f8')
+            dtypes = [('atom', str), ('x', float), ('y', float), ('z', float)]
+            frame = pd.DataFrame(np.empty(len(atoms), dtype=dtypes), index=index)
             frame['atom'] = atoms
             frame.loc[:, ['x', 'y', 'z']] = coords
         elif not isinstance(frame, pd.DataFrame):
@@ -234,10 +234,6 @@ class CartesianCore(PandasWrapper, GenericCore):
 
     def __ne__(self, other):
         return self._frame != other._frame
-
-    def _to_numeric(self):
-        return self.__class__(self._frame.apply(
-            partial(pd.to_numeric, errors='ignore')))
 
     def copy(self):
         molecule = self.__class__(self._frame)

--- a/src/chemcoord/cartesian_coordinates/_cartesian_class_get_zmat.py
+++ b/src/chemcoord/cartesian_coordinates/_cartesian_class_get_zmat.py
@@ -696,7 +696,7 @@ class CartesianGetZmat(CartesianCore):
         c_table = construction_table.loc[:, ['b', 'a', 'd']]
         c_table = c_table.replace(constants.int_label)
         c_table = c_table.replace({k: v for v, k in enumerate(c_table.index)})
-        c_table = c_table.values.T
+        c_table = c_table.astype('i8').values.T
         X = self.loc[:, ['x', 'y', 'z']].values.T
         if X.dtype == np.dtype('i8'):
             X = X.astype('f8')

--- a/src/chemcoord/cartesian_coordinates/_cartesian_class_get_zmat.py
+++ b/src/chemcoord/cartesian_coordinates/_cartesian_class_get_zmat.py
@@ -18,6 +18,7 @@ from chemcoord.exceptions import (ERR_CODE_OK, ERR_CODE_InvalidReference,
                                   IllegalArgumentCombination, InvalidReference,
                                   UndefinedCoordinateSystem)
 from chemcoord.internal_coordinates.zmat_class_main import Zmat
+from chemcoord.utilities._temporary_deprecation_workarounds import replace_without_warn
 
 
 class CartesianGetZmat(CartesianCore):
@@ -489,7 +490,8 @@ class CartesianGetZmat(CartesianCore):
                 c_table = pd.DataFrame(
                     data=c_table[:, 1:], index=c_table[:, 0],
                     columns=['b', 'a', 'd'])
-        c_table = c_table.replace(constants.int_label).astype('i8')
+
+        c_table = replace_without_warn(c_table, constants.int_label).astype('i8')
         c_table.index = c_table.index.astype('i8')
 
         new_index = c_table.index.append(self.index.difference(c_table.index))
@@ -694,9 +696,13 @@ class CartesianGetZmat(CartesianCore):
             message = "construction_table and self must use the same index"
             raise ValueError(message)
         c_table = construction_table.loc[:, ['b', 'a', 'd']]
-        c_table = c_table.replace(constants.int_label)
-        c_table = c_table.replace({k: v for v, k in enumerate(c_table.index)})
-        c_table = c_table.astype('i8').values.T
+
+
+        c_table = (replace_without_warn(c_table, constants.int_label)
+                        .astype('i8')
+                        .replace({k: v for v, k in enumerate(c_table.index)})
+                        .values
+                        .T)
         X = self.loc[:, ['x', 'y', 'z']].values.T
         if X.dtype == np.dtype('i8'):
             X = X.astype('f8')

--- a/src/chemcoord/cartesian_coordinates/_cartesian_class_io.py
+++ b/src/chemcoord/cartesian_coordinates/_cartesian_class_io.py
@@ -359,9 +359,8 @@ class CartesianIO(CartesianCore, GenericIO):
         Returns:
             Cartesian:
         """
-        new = cls(atoms=[el.value for el in molecule.species],
-                  coords=molecule.cart_coords)
-        return new._to_numeric()
+        return cls(atoms=[el.value for el in molecule.species],
+                   coords=molecule.cart_coords)
 
     def get_ase_atoms(self):
         """Create an Atoms instance of the ase library

--- a/src/chemcoord/cartesian_coordinates/_cartesian_class_symmetry.py
+++ b/src/chemcoord/cartesian_coordinates/_cartesian_class_symmetry.py
@@ -20,7 +20,7 @@ class CartesianSymmetry(CartesianCore):
         try:
             sym_mol = self.from_pymatgen_molecule(eq['sym_mol'])
             sym_mol.index = self.index
-            eq['sym_mol'] = sym_mol._to_numeric()
+            eq['sym_mol'] = sym_mol
         except KeyError:
             pass
 

--- a/src/chemcoord/cartesian_coordinates/_indexers.py
+++ b/src/chemcoord/cartesian_coordinates/_indexers.py
@@ -38,7 +38,7 @@ class _Loc(_generic_Indexer):
             # The `except FutureWarning:` has likely to become `except TypeError:`
             #  then in the future.
             if isinstance(key, tuple):
-                if type(key[1]) is not str and is_iterable(key[1]):
+                if type(key[1]) is not str and _is_iterable(key[1]):
                     self.molecule._frame = df.astype({k: 'O' for k in key[1]})
                 else:
                     self.molecule._frame = df.astype({key[1]: 'O'})
@@ -79,9 +79,9 @@ class _ILoc(_generic_Indexer):
             #  then in the future.
             if isinstance(key, tuple):
                 if type(key[1]) is not str and _is_iterable(key[1]):
-                    self.molecule._frame = df.astype({k: 'O' for k in key[1]})
+                    self.molecule._frame = df.astype({df.columns[k]: 'O' for k in key[1]})
                 else:
-                    self.molecule._frame = df.astype({key[1]: 'O'})
+                    self.molecule._frame = df.astype({df.columns[key[1]]: 'O'})
                 self.molecule._frame.iloc[_set_caster(key[0]), _set_caster(key[1])] = value
             else:
                 raise TypeError("Assignment not supported.")

--- a/src/chemcoord/cartesian_coordinates/_indexers.py
+++ b/src/chemcoord/cartesian_coordinates/_indexers.py
@@ -2,6 +2,8 @@
 
 import warnings
 
+from chemcoord.utilities._temporary_deprecation_workarounds import is_iterable
+
 class _generic_Indexer(object):
     def __init__(self, molecule):
         self.molecule = molecule
@@ -38,7 +40,7 @@ class _Loc(_generic_Indexer):
             # The `except FutureWarning:` has likely to become `except TypeError:`
             #  then in the future.
             if isinstance(key, tuple):
-                if type(key[1]) is not str and _is_iterable(key[1]):
+                if type(key[1]) is not str and is_iterable(key[1]):
                     self.molecule._frame = df.astype({k: 'O' for k in key[1]})
                 else:
                     self.molecule._frame = df.astype({key[1]: 'O'})
@@ -78,7 +80,7 @@ class _ILoc(_generic_Indexer):
             # The `except FutureWarning:` has likely to become `except TypeError:`
             #  then in the future.
             if isinstance(key, tuple):
-                if type(key[1]) is not str and _is_iterable(key[1]):
+                if type(key[1]) is not str and is_iterable(key[1]):
                     self.molecule._frame = df.astype({df.columns[k]: 'O' for k in key[1]})
                 else:
                     self.molecule._frame = df.astype({df.columns[key[1]]: 'O'})
@@ -97,12 +99,3 @@ def _set_caster(x):
         return list(x)
     else:
         return x
-
-
-def _is_iterable(x):
-    try:
-        # check if iterable
-        iter(x)
-        return True
-    except TypeError:
-        return False

--- a/src/chemcoord/cartesian_coordinates/_indexers.py
+++ b/src/chemcoord/cartesian_coordinates/_indexers.py
@@ -78,7 +78,7 @@ class _ILoc(_generic_Indexer):
             # The `except FutureWarning:` has likely to become `except TypeError:`
             #  then in the future.
             if isinstance(key, tuple):
-                if type(key[1]) is not str and is_iterable(key[1]):
+                if type(key[1]) is not str and _is_iterable(key[1]):
                     self.molecule._frame = df.astype({k: 'O' for k in key[1]})
                 else:
                     self.molecule._frame = df.astype({key[1]: 'O'})
@@ -97,3 +97,12 @@ def _set_caster(x):
         return list(x)
     else:
         return x
+
+
+def _is_iterable(x):
+    try:
+        # check if iterable
+        iter(x)
+        return True
+    except TypeError:
+        return False

--- a/src/chemcoord/cartesian_coordinates/_indexers.py
+++ b/src/chemcoord/cartesian_coordinates/_indexers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import warnings
 
 class _generic_Indexer(object):
     def __init__(self, molecule):
@@ -19,10 +20,31 @@ class _Loc(_generic_Indexer):
             return selected
 
     def __setitem__(self, key, value):
-        if isinstance(key, tuple):
-            self.molecule._frame.loc[_set_caster(key[0]), _set_caster(key[1])] = value
-        else:
-            self.molecule._frame.loc[_set_caster(key)] = value
+        df = self.molecule._frame
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", category=FutureWarning)
+                if isinstance(key, tuple):
+                    df.loc[_set_caster(key[0]), _set_caster(key[1])] = value
+                else:
+                    df.loc[_set_caster(key)] = value
+        except FutureWarning:
+            # We have the situation where value is of different type than
+            #  the columns we assign to.
+            # This happens for example when assigning sympy objects,
+            #  i.e. symbolic variables, to a float column.
+            # Currently this is not a problem in pandas and only raises a FutureWarning
+            #  (as of version 2.2.), but to be futureproof make an explicit cast.
+            # The `except FutureWarning:` has likely to become `except TypeError:`
+            #  then in the future.
+            if isinstance(key, tuple):
+                if type(key[1]) is not str and is_iterable(key[1]):
+                    self.molecule._frame = df.astype({k: 'O' for k in key[1]})
+                else:
+                    self.molecule._frame = df.astype({key[1]: 'O'})
+                self.molecule._frame.loc[_set_caster(key[0]), _set_caster(key[1])] = value
+            else:
+                raise TypeError("Assignment not supported.")
 
 
 class _ILoc(_generic_Indexer):
@@ -38,10 +60,31 @@ class _ILoc(_generic_Indexer):
             return selected
 
     def __setitem__(self, key, value):
-        if isinstance(key, tuple):
-            self.molecule._frame.iloc[_set_caster(key[0]), _set_caster(key[1])] = value
-        else:
-            self.molecule._frame.iloc[_set_caster(key)] = value
+        df = self.molecule._frame
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", category=FutureWarning)
+                if isinstance(key, tuple):
+                    df.iloc[_set_caster(key[0]), _set_caster(key[1])] = value
+                else:
+                    df.iloc[_set_caster(key)] = value
+        except FutureWarning:
+            # We have the situation where value is of different type than
+            #  the columns we assign to.
+            # This happens for example when assigning sympy objects,
+            #  i.e. symbolic variables, to a float column.
+            # Currently this is not a problem in pandas and only raises a FutureWarning
+            #  (as of version 2.2.), but to be futureproof make an explicit cast.
+            # The `except FutureWarning:` has likely to become `except TypeError:`
+            #  then in the future.
+            if isinstance(key, tuple):
+                if type(key[1]) is not str and is_iterable(key[1]):
+                    self.molecule._frame = df.astype({k: 'O' for k in key[1]})
+                else:
+                    self.molecule._frame = df.astype({key[1]: 'O'})
+                self.molecule._frame.iloc[_set_caster(key[0]), _set_caster(key[1])] = value
+            else:
+                raise TypeError("Assignment not supported.")
 
 
 

--- a/src/chemcoord/cartesian_coordinates/xyz_functions.py
+++ b/src/chemcoord/cartesian_coordinates/xyz_functions.py
@@ -479,11 +479,14 @@ def apply_grad_zmat_tensor(grad_C, construction_table, cart_dist):
         C_dist[:, [1, 2]] = sympy.deg(C_dist[:, [1, 2]])
 
     from chemcoord.internal_coordinates.zmat_class_main import Zmat
-    cols = ['atom', 'b', 'bond', 'a', 'angle', 'd', 'dihedral']
-    dtypes = ['O', 'i8', 'f8', 'i8', 'f8', 'i8', 'f8']
-    new = pd.DataFrame(data=np.zeros((len(construction_table), 7)),
-                       index=cart_dist.index, columns=cols, dtype='f8')
-    new = new.astype(dict(zip(cols, dtypes)))
+    dtypes = [('atom', str),
+                    ('b', str), ('bond', float),
+                    ('a', str), ('angle', float),
+                    ('d', str), ('dihedral', float)]
+
+    new = pd.DataFrame(np.empty(len(construction_table), dtype=dtypes),
+                              index=cart_dist.index)
+
     new.loc[:, ['b', 'a', 'd']] = construction_table
     new.loc[:, 'atom'] = cart_dist.loc[:, 'atom']
     new.loc[:, ['bond', 'angle', 'dihedral']] = C_dist

--- a/src/chemcoord/cartesian_coordinates/xyz_functions.py
+++ b/src/chemcoord/cartesian_coordinates/xyz_functions.py
@@ -200,7 +200,7 @@ def isclose(a, b, align=False, rtol=1.e-5, atol=1.e-8):
     """
     coords = ['x', 'y', 'z']
     if not (set(a.index) == set(b.index)
-            and np.alltrue(a.loc[:, 'atom'] == b.loc[a.index, 'atom'])):
+            and (a.loc[:, 'atom'] == b.loc[a.index, 'atom']).all(axis=None)):
         message = 'Can only compare molecules with the same atoms and labels'
         raise ValueError(message)
 
@@ -231,7 +231,7 @@ def allclose(a, b, align=False, rtol=1.e-5, atol=1.e-8):
     Returns:
         bool:
     """
-    return np.alltrue(isclose(a, b, align=align, rtol=rtol, atol=atol))
+    return isclose(a, b, align=align, rtol=rtol, atol=atol).all(axis=None)
 
 
 def concat(cartesians, ignore_index=False, keys=None):

--- a/src/chemcoord/cartesian_coordinates/xyz_functions.py
+++ b/src/chemcoord/cartesian_coordinates/xyz_functions.py
@@ -208,8 +208,9 @@ def isclose(a, b, align=False, rtol=1.e-5, atol=1.e-8):
         a = a.get_inertia()['transformed_Cartesian']
         b = b.get_inertia()['transformed_Cartesian']
     A, B = a.loc[:, coords], b.loc[a.index, coords]
-    out = a._frame.copy()
-    out['atom'] = True
+
+    out = pd.DataFrame(index=a.index, columns=['atom'] + coords, dtype=bool)
+    out.loc[:, 'atom'] = True
     out.loc[:, coords] = np.isclose(A, B, rtol=rtol, atol=atol)
     return out
 

--- a/src/chemcoord/internal_coordinates/_indexers.py
+++ b/src/chemcoord/internal_coordinates/_indexers.py
@@ -42,7 +42,7 @@ class _Unsafe_base():
             #  (as of version 2.2.), but to be futureproof make an explicit cast.
             # The `except FutureWarning:` has likely to become `except TypeError:` then.
             if isinstance(key, tuple):
-                if type(key[1]) is not str and is_iterable(key[1]):
+                if type(key[1]) is not str and _is_iterable(key[1]):
                     self.molecule._frame = self.molecule._frame.astype({k: 'O' for k in key[1]})
                 else:
                     self.molecule._frame = self.molecule._frame.astype({key[1]: 'O'})
@@ -117,7 +117,7 @@ class _Safe_ILoc(_ILoc, _SafeBase):
 
 
 
-def is_iterable(x):
+def _is_iterable(x):
     try:
         # check if iterable
         iter(x)

--- a/src/chemcoord/internal_coordinates/_indexers.py
+++ b/src/chemcoord/internal_coordinates/_indexers.py
@@ -2,7 +2,7 @@
 
 import warnings
 from chemcoord.exceptions import InvalidReference
-
+from chemcoord.utilities._temporary_deprecation_workarounds import is_iterable
 
 class _generic_Indexer(object):
     def __init__(self, molecule):
@@ -42,7 +42,7 @@ class _Unsafe_base():
             #  (as of version 2.2.), but to be futureproof make an explicit cast.
             # The `except FutureWarning:` has likely to become `except TypeError:` then.
             if isinstance(key, tuple):
-                if type(key[1]) is not str and _is_iterable(key[1]):
+                if type(key[1]) is not str and is_iterable(key[1]):
                     self.molecule._frame = self.molecule._frame.astype({k: 'O' for k in key[1]})
                 else:
                     self.molecule._frame = self.molecule._frame.astype({key[1]: 'O'})
@@ -114,13 +114,3 @@ class _Unsafe_ILoc(_ILoc, _Unsafe_base):
 
 class _Safe_ILoc(_ILoc, _SafeBase):
     pass
-
-
-
-def _is_iterable(x):
-    try:
-        # check if iterable
-        iter(x)
-        return True
-    except TypeError:
-        return False

--- a/src/chemcoord/internal_coordinates/_indexers.py
+++ b/src/chemcoord/internal_coordinates/_indexers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import warnings
 from chemcoord.exceptions import InvalidReference
 
 
@@ -24,11 +25,32 @@ class _ILoc(_generic_Indexer):
 
 class _Unsafe_base():
     def __setitem__(self, key, value):
-        indexer = getattr(self.molecule._frame, self.indexer)
-        if isinstance(key, tuple):
-            indexer[key[0], key[1]] = value
-        else:
-            indexer[key] = value
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", category=FutureWarning)
+                indexer = getattr(self.molecule._frame, self.indexer)
+                if isinstance(key, tuple):
+                    indexer[key[0], key[1]] = value
+                else:
+                    indexer[key] = value
+        except FutureWarning:
+            # We have the situation where value is of different type than
+            #  the columns we assign to.
+            # This happens for example when assigning sympy objects,
+            #  i.e. symbolic variables, to a float column.
+            # Currently this is not a problem in pandas and only raises a FutureWarning
+            #  (as of version 2.2.), but to be futureproof make an explicit cast.
+            # The `except FutureWarning:` has likely to become `except TypeError:` then.
+            if isinstance(key, tuple):
+                if type(key[1]) is not str and is_iterable(key[1]):
+                    self.molecule._frame = self.molecule._frame.astype({k: 'O' for k in key[1]})
+                else:
+                    self.molecule._frame = self.molecule._frame.astype({key[1]: 'O'})
+                indexer = getattr(self.molecule._frame, self.indexer)
+                indexer[key[0], key[1]] = value
+            else:
+                raise TypeError("Assignment not supported.")
+
 
 class _SafeBase():
     def __setitem__(self, key, value):
@@ -95,3 +117,13 @@ class _Unsafe_ILoc(_ILoc, _Unsafe_base):
 
 class _Safe_ILoc(_ILoc, _SafeBase):
     pass
+
+
+
+def is_iterable(x):
+    try:
+        # check if iterable
+        iter(x)
+        return True
+    except TypeError:
+        return False

--- a/src/chemcoord/internal_coordinates/_indexers.py
+++ b/src/chemcoord/internal_coordinates/_indexers.py
@@ -64,12 +64,9 @@ class _SafeBase():
             molecule = self.molecule
         else:
             molecule = self.molecule.copy()
-        indexer = getattr(molecule._frame, self.indexer)
 
-        if isinstance(key, tuple):
-            indexer[key[0], key[1]] = value
-        else:
-            indexer[key] = value
+        indexer = getattr(molecule, f'unsafe_{self.indexer}')
+        indexer[key] = value
 
         try:
             molecule.get_cartesian()

--- a/src/chemcoord/internal_coordinates/_zmat_class_core.py
+++ b/src/chemcoord/internal_coordinates/_zmat_class_core.py
@@ -768,7 +768,7 @@ and assigning values safely.
         """
         zmat = self.change_numbering()
         c_table = zmat.loc[:, ['b', 'a', 'd']]
-        c_table = c_table.replace(constants.int_label).values.T
+        c_table = c_table.replace(constants.int_label).astype('i8').values.T
         C = zmat.loc[:, ['bond', 'angle', 'dihedral']].values.T
         if C.dtype == np.dtype('i8'):
             C = C.astype('f8')

--- a/src/chemcoord/internal_coordinates/_zmat_class_core.py
+++ b/src/chemcoord/internal_coordinates/_zmat_class_core.py
@@ -292,27 +292,27 @@ and assigning values safely.
         return new
 
     def iupacify(self):
-        """Give the IUPAC conform representation.
+        r"""Give the IUPAC conform representation.
 
         Mathematically speaking the angles in a zmatrix are
         representations of an equivalence class.
-        We will denote an equivalence relation with :math:`\\sim`
-        and use :math:`\\alpha` for an angle and :math:`\\delta` for a dihedral
+        We will denote an equivalence relation with :math:`\sim`
+        and use :math:`\alpha` for an angle and :math:`\delta` for a dihedral
         angle. Then the following equations hold true.
 
         .. math::
 
-           (\\alpha, \\delta) &\sim (-\\alpha, \\delta + \\pi) \\\\
-           \\alpha &\sim \\alpha \\mod 2\\pi \\\\
-           \\delta &\sim \\delta \\mod 2\\pi
+           (\alpha, \delta) &\sim (-\alpha, \delta + \pi) \\
+           \alpha &\sim \alpha \mod 2\pi \\
+           \delta &\sim \delta \mod 2\pi
 
         `IUPAC <https://goldbook.iupac.org/html/T/T06406.html>`_ defines
         a designated representation of these equivalence classes, by asserting:
 
         .. math::
 
-           0 \\leq &\\alpha \\leq \\pi \\\\
-           -\\pi \\leq &\\delta \\leq \\pi
+           0 \leq &\alpha \leq \pi \\
+           -\pi \leq &\delta \leq \pi
 
         Args:
             None
@@ -437,7 +437,7 @@ and assigning values safely.
             if out.loc[:, col].dtype is np.dtype('O'):
                 out.unsafe_loc[:, col] = out.loc[:, col].map(get_subs_f(*args))
                 try:
-                    out._frame[col] = out.loc[:, col].astype('f8')
+                    out._frame = out._frame.astype({col: 'f8'})
                 except (SystemError, TypeError):
                     pass
         if perform_checks:

--- a/src/chemcoord/internal_coordinates/_zmat_class_core.py
+++ b/src/chemcoord/internal_coordinates/_zmat_class_core.py
@@ -152,8 +152,8 @@ and assigning values safely.
 
     def _test_if_can_be_added(self, other):
         cols = ['atom', 'b', 'a', 'd']
-        if not (np.alltrue(self.loc[:, cols] == other.loc[:, cols])
-                and np.alltrue(self.index == other.index)):
+        if not ((self.loc[:, cols] == other.loc[:, cols]).all(axis=None)
+                and (self.index == other.index).all()):
             message = ("You can add only those zmatrices that have the same "
                        "index, use the same construction table, have the same "
                        "ordering... The only allowed difference is in the "

--- a/src/chemcoord/internal_coordinates/_zmat_class_io.py
+++ b/src/chemcoord/internal_coordinates/_zmat_class_io.py
@@ -113,7 +113,7 @@ class ZmatIO(ZmatCore, GenericIO):
                          ['origin', 'e_z', 'e_x']]
             for row, i in enumerate(zmat_frame.index[:3]):
                 cols = ['b', 'a', 'd']
-                zmat_frame.loc[:, cols] = zmat_frame.loc[:, cols].astype('O')
+                zmat_frame = zmat_frame.astype({k: 'O' for k in cols})
                 if row < 2:
                     zmat_frame.loc[i, cols[row:]] = zmat_refs[row:]
                     zmat_frame.loc[i, ['bond', 'angle', 'dihedral'][row:]

--- a/src/chemcoord/internal_coordinates/_zmat_class_io.py
+++ b/src/chemcoord/internal_coordinates/_zmat_class_io.py
@@ -43,6 +43,7 @@ class ZmatIO(ZmatCore, GenericIO):
 
     def _remove_upper_triangle(self):
         out = self.copy()
+        out._frame = out._frame.astype({k: str for k in ['b', 'bond', 'a', 'angle', 'd', 'dihedral']})
         for i in range(min(len(self), 3)):
             out.unsafe_iloc[i, (2 * i + 1):] = ''
         return out

--- a/src/chemcoord/utilities/_temporary_deprecation_workarounds.py
+++ b/src/chemcoord/utilities/_temporary_deprecation_workarounds.py
@@ -13,3 +13,16 @@ def replace_without_warn(df, *replace_args, **replace_kwargs):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=FutureWarning)
             return df.replace(*replace_args, **replace_kwargs)
+
+
+def is_iterable(x):
+    """Check if `x` is iterable
+
+    The test via exceptions is actually recommended
+    https://docs.python.org/3/library/collections.abc.html#collections.abc.Iterable
+    """
+    try:
+        iter(x)
+        return True
+    except TypeError:
+        return False

--- a/src/chemcoord/utilities/_temporary_deprecation_workarounds.py
+++ b/src/chemcoord/utilities/_temporary_deprecation_workarounds.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+import warnings
+
+def replace_without_warn(df, *replace_args, **replace_kwargs):
+        """Call the `replace` method of a dataframe while filtering `FutureWarning`
+
+        The warning about:
+        [...] Downcasting behavior in `replace` is deprecated [...]
+        is already fixed in the code.
+        We can remove this warning filter in the future.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=FutureWarning)
+            return df.replace(*replace_args, **replace_kwargs)

--- a/tests/cartesian_coordinates/Cartesian/test_back_forth.py
+++ b/tests/cartesian_coordinates/Cartesian/test_back_forth.py
@@ -7,7 +7,11 @@ import os
 import sys
 
 import pandas as pd
-pd.set_option("future.no_silent_downcasting", True)
+try:
+    pd.set_option("future.no_silent_downcasting", True)
+except:
+    # Yes I want a bare except
+    pass
 
 
 def get_script_path():

--- a/tests/cartesian_coordinates/Cartesian/test_back_forth.py
+++ b/tests/cartesian_coordinates/Cartesian/test_back_forth.py
@@ -6,6 +6,9 @@ import itertools
 import os
 import sys
 
+import pandas as pd
+pd.set_option("future.no_silent_downcasting", True)
+
 
 def get_script_path():
     return os.path.dirname(os.path.realpath(__file__))

--- a/tests/cartesian_coordinates/Cartesian/test_core.py
+++ b/tests/cartesian_coordinates/Cartesian/test_core.py
@@ -5,6 +5,8 @@ import sys
 import numpy as np
 import pytest
 
+import sympy
+
 import chemcoord as cc
 from chemcoord.cartesian_coordinates.xyz_functions import (dot,
                                                            get_rotation_matrix)
@@ -134,6 +136,20 @@ def test_indexing():
     assert (molecule.y == molecule.loc[:, 'y']).all()
     assert (molecule.z == molecule.loc[:, 'z']).all()
     assert ((molecule.x - molecule.loc[:, 'x']) == 0).all()
+
+def test_assignment():
+    molecule = cc.Cartesian.read_xyz(get_complete_path('MIL53_small.xyz'),
+                                     start_index=1)
+    x = sympy.symbols('x', real=True)
+
+    molecule.loc[:, 'x'] = 3
+    assert (molecule.x == 3).all()
+
+    molecule.loc[1, 'x'] = x
+    assert molecule.x.dtypes == np.dtype('O')
+    assert molecule.y.dtypes == np.dtype('f8')
+    molecule = molecule.subs(x, 1)
+    assert molecule.x.dtypes == np.dtype('f8')
 
 
 def test_get_bonds():

--- a/tests/cartesian_coordinates/Cartesian/test_core.py
+++ b/tests/cartesian_coordinates/Cartesian/test_core.py
@@ -171,9 +171,8 @@ def test_coordination_sphere():
 def test_cut_sphere():
     expected = {6, 7, 8, 9, 11, 12, 13, 15, 16, 19, 20, 53}
     assert expected == set(molecule.cut_sphere(radius=3, origin=7).index)
-    assert np.alltrue(
-        molecule == molecule.cut_sphere(radius=3, origin=7,
-                                        preserve_bonds=True))
+    assert (molecule == molecule.cut_sphere(radius=3, origin=7,
+                                            preserve_bonds=True)).all(axis=None)
     assert (set(molecule.index) - expected
             == set(molecule.cut_sphere(radius=3, origin=7,
                                        outside_sliced=False).index))
@@ -182,9 +181,8 @@ def test_cut_sphere():
 def test_cut_cuboid():
     expected = {3, 4, 5, 6, 7, 15, 16, 17, 32, 35, 37, 38, 47, 52, 53, 55, 56}
     assert expected == set(molecule.cut_cuboid(a=2, origin=7).index)
-    assert np.alltrue(
-        molecule == molecule.cut_cuboid(a=2, origin=7,
-                                        preserve_bonds=True))
+    assert (molecule == molecule.cut_cuboid(a=2, origin=7,
+                                        preserve_bonds=True)).all(axis=None)
     assert (set(molecule.index) - expected
             == set(molecule.cut_cuboid(a=2, origin=7,
                                        outside_sliced=False).index))
@@ -240,7 +238,7 @@ def test_change_numbering():
     molecule2 = molecule.copy()
     molecule2.index = reversed(molecule.index)
     dct = dict(zip(molecule.index, reversed(molecule.index)))
-    assert np.alltrue(molecule2.index == molecule.change_numbering(dct).index)
+    assert (molecule2.index == molecule.change_numbering(dct).index).all()
 
 
 def test_align():

--- a/tests/cartesian_coordinates/Cartesian/test_core.py
+++ b/tests/cartesian_coordinates/Cartesian/test_core.py
@@ -151,6 +151,43 @@ def test_assignment():
     molecule = molecule.subs(x, 1)
     assert molecule.x.dtypes == np.dtype('f8')
 
+    molecule.loc[1, ['x', 'y']] = x
+    assert molecule.x.dtypes == np.dtype('O')
+    assert molecule.y.dtypes == np.dtype('O')
+    molecule = molecule.subs(x, 1)
+    assert molecule.x.dtypes == np.dtype('f8')
+    assert molecule.y.dtypes == np.dtype('f8')
+
+    with pytest.raises(TypeError):
+        molecule.loc[1] = x
+    with pytest.raises(TypeError):
+        molecule.loc[[1, 2]] = x
+
+    molecule = cc.Cartesian.read_xyz(get_complete_path('MIL53_small.xyz'),
+                                     start_index=1)
+    x = sympy.symbols('x', real=True)
+
+    molecule.iloc[:, 1] = 3
+    assert (molecule.x == 3).all()
+
+    molecule.iloc[1, 1] = x
+    assert molecule.x.dtypes == np.dtype('O')
+    assert molecule.y.dtypes == np.dtype('f8')
+    molecule = molecule.subs(x, 1)
+    assert molecule.x.dtypes == np.dtype('f8')
+
+    molecule.iloc[1, [1, 2]] = x
+    assert molecule.x.dtypes == np.dtype('O')
+    assert molecule.y.dtypes == np.dtype('O')
+    molecule = molecule.subs(x, 1)
+    assert molecule.x.dtypes == np.dtype('f8')
+    assert molecule.y.dtypes == np.dtype('f8')
+
+    with pytest.raises(TypeError):
+        molecule.iloc[1] = x
+    with pytest.raises(TypeError):
+        molecule.iloc[[1, 2]] = x
+
 
 def test_get_bonds():
     assert bond_dict == molecule.get_bonds()

--- a/tests/cartesian_coordinates/Cartesian/test_core.py
+++ b/tests/cartesian_coordinates/Cartesian/test_core.py
@@ -11,6 +11,12 @@ from chemcoord.cartesian_coordinates.xyz_functions import (dot,
 from chemcoord.exceptions import PhysicalMeaning, UndefinedCoordinateSystem
 from chemcoord.xyz_functions import allclose
 
+import pandas as pd
+try:
+    pd.set_option("future.no_silent_downcasting", True)
+except:
+    # Yes I want a bare except
+    pass
 
 def get_script_path():
     return os.path.dirname(os.path.realpath(__file__))

--- a/tests/cartesian_coordinates/Cartesian/test_core.py
+++ b/tests/cartesian_coordinates/Cartesian/test_core.py
@@ -158,10 +158,6 @@ def test_assignment():
     assert molecule.x.dtypes == np.dtype('f8')
     assert molecule.y.dtypes == np.dtype('f8')
 
-    with pytest.raises(TypeError):
-        molecule.loc[1] = x
-    with pytest.raises(TypeError):
-        molecule.loc[[1, 2]] = x
 
     molecule = cc.Cartesian.read_xyz(get_complete_path('MIL53_small.xyz'),
                                      start_index=1)
@@ -183,10 +179,6 @@ def test_assignment():
     assert molecule.x.dtypes == np.dtype('f8')
     assert molecule.y.dtypes == np.dtype('f8')
 
-    with pytest.raises(TypeError):
-        molecule.iloc[1] = x
-    with pytest.raises(TypeError):
-        molecule.iloc[[1, 2]] = x
 
 
 def test_get_bonds():

--- a/tests/cartesian_coordinates/Cartesian/test_geometry_calcs.py
+++ b/tests/cartesian_coordinates/Cartesian/test_geometry_calcs.py
@@ -4,8 +4,11 @@ import numpy as np
 import os
 import sys
 import pandas as pd
-
-pd.set_option('future.no_silent_downcasting', True)
+try:
+    pd.set_option("future.no_silent_downcasting", True)
+except:
+    # Yes I want a bare except
+    pass
 
 
 def get_script_path():

--- a/tests/cartesian_coordinates/Cartesian/test_geometry_calcs.py
+++ b/tests/cartesian_coordinates/Cartesian/test_geometry_calcs.py
@@ -3,6 +3,9 @@ import pytest
 import numpy as np
 import os
 import sys
+import pandas as pd
+
+pd.set_option('future.no_silent_downcasting', True)
 
 
 def get_script_path():
@@ -44,7 +47,7 @@ def test_get_dihedral_degrees():
 def test_fragmentate():
     fragments = molecule.fragmentate()
     assert len(fragments) == 1
-    assert np.alltrue(fragments[0] == molecule)
+    assert (fragments[0] == molecule).all(axis=None)
 
 
 def test_get_shortest_distance():

--- a/tests/cartesian_coordinates/Cartesian/test_get_bonds.py
+++ b/tests/cartesian_coordinates/Cartesian/test_get_bonds.py
@@ -3,6 +3,12 @@ import pytest
 import numpy as np
 import os
 import sys
+import pandas as pd
+try:
+    pd.set_option("future.no_silent_downcasting", True)
+except:
+    # Yes I want a bare except
+    pass
 
 
 def get_script_path():

--- a/tests/cartesian_coordinates/Cartesian/test_grad_zmat.py
+++ b/tests/cartesian_coordinates/Cartesian/test_grad_zmat.py
@@ -9,10 +9,13 @@ import pytest
 import sympy
 from chemcoord.exceptions import UndefinedCoordinateSystem
 from chemcoord.xyz_functions import allclose
-
-
 import pandas as pd
-pd.set_option("future.no_silent_downcasting", True)
+
+try:
+    pd.set_option("future.no_silent_downcasting", True)
+except:
+    # Yes I want a bare except
+    pass
 
 def get_script_path():
     return os.path.dirname(os.path.realpath(__file__))

--- a/tests/cartesian_coordinates/Cartesian/test_grad_zmat.py
+++ b/tests/cartesian_coordinates/Cartesian/test_grad_zmat.py
@@ -53,5 +53,4 @@ def test_grad_zmat():
         (zmat_dist.loc[:, ['bond', 'angle', 'dihedral']] != 0.).any(axis=1)]
 
     assert moved_atoms[0] == 13
-    assert np.alltrue(
-        moved_atoms[1:] == c_table.index[(c_table == 13).any(axis=1)])
+    assert (moved_atoms[1:] == c_table.index[(c_table == 13).any(axis=1)]).all()

--- a/tests/cartesian_coordinates/Cartesian/test_grad_zmat.py
+++ b/tests/cartesian_coordinates/Cartesian/test_grad_zmat.py
@@ -11,6 +11,9 @@ from chemcoord.exceptions import UndefinedCoordinateSystem
 from chemcoord.xyz_functions import allclose
 
 
+import pandas as pd
+pd.set_option("future.no_silent_downcasting", True)
+
 def get_script_path():
     return os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/cartesian_coordinates/Cartesian/test_io.py
+++ b/tests/cartesian_coordinates/Cartesian/test_io.py
@@ -6,6 +6,13 @@ import itertools
 import numpy as np
 import os
 import sys
+import pandas as pd
+
+try:
+    pd.set_option("future.no_silent_downcasting", True)
+except:
+    # Yes I want a bare except
+    pass
 
 
 def get_script_path():

--- a/tests/cartesian_coordinates/Cartesian/test_pandas_wrapper.py
+++ b/tests/cartesian_coordinates/Cartesian/test_pandas_wrapper.py
@@ -6,6 +6,13 @@ import itertools
 import numpy as np
 import os
 import sys
+import pandas as pd
+
+try:
+    pd.set_option("future.no_silent_downcasting", True)
+except:
+    # Yes I want a bare except
+    pass
 
 
 def get_script_path():

--- a/tests/cartesian_coordinates/Cartesian/test_symmetry.py
+++ b/tests/cartesian_coordinates/Cartesian/test_symmetry.py
@@ -2,6 +2,13 @@ import os
 
 import chemcoord as cc
 import numpy as np
+import pandas as pd
+
+try:
+    pd.set_option("future.no_silent_downcasting", True)
+except:
+    # Yes I want a bare except
+    pass
 
 
 def get_script_path():

--- a/tests/cartesian_coordinates/xyz_functions/test_xyz_functions.py
+++ b/tests/cartesian_coordinates/xyz_functions/test_xyz_functions.py
@@ -6,6 +6,8 @@ import itertools
 import numpy as np
 import os
 import sys
+import pandas as pd
+pd.set_option("future.no_silent_downcasting", True)
 
 
 def get_script_path():
@@ -39,7 +41,7 @@ def test_concat():
         molecule2.index = molecule.index
         assert allclose(molecule, molecule2)
 
-    key_joined = cc.xyz_functions.concat(cartesians, keys=['a', 'b'])
+    key_joined = cc.xyz_functions.concat(cartesians, keys=['a', 'b', 'c', 'd', 'e'])
     assert allclose(key_joined.loc['a'], (key_joined.loc['b'] - 10))
 
 

--- a/tests/cartesian_coordinates/xyz_functions/test_xyz_functions.py
+++ b/tests/cartesian_coordinates/xyz_functions/test_xyz_functions.py
@@ -7,7 +7,12 @@ import numpy as np
 import os
 import sys
 import pandas as pd
-pd.set_option("future.no_silent_downcasting", True)
+
+try:
+    pd.set_option("future.no_silent_downcasting", True)
+except:
+    # Yes I want a bare except
+    pass
 
 
 def get_script_path():

--- a/tests/internal_coordinates/Zmat/test_grad_cartesian.py
+++ b/tests/internal_coordinates/Zmat/test_grad_cartesian.py
@@ -9,6 +9,7 @@ import pytest
 from chemcoord.exceptions import UndefinedCoordinateSystem
 from chemcoord.xyz_functions import allclose
 
+pd.set_option("future.no_silent_downcasting", True)
 
 def get_script_path():
     return os.path.dirname(os.path.realpath(__file__))

--- a/tests/internal_coordinates/Zmat/test_grad_cartesian.py
+++ b/tests/internal_coordinates/Zmat/test_grad_cartesian.py
@@ -4,12 +4,16 @@ import sys
 
 import chemcoord as cc
 import numpy as np
-import pandas as pd
 import pytest
 from chemcoord.exceptions import UndefinedCoordinateSystem
 from chemcoord.xyz_functions import allclose
+import pandas as pd
 
-pd.set_option("future.no_silent_downcasting", True)
+try:
+    pd.set_option("future.no_silent_downcasting", True)
+except:
+    # Yes I want a bare except
+    pass
 
 def get_script_path():
     return os.path.dirname(os.path.realpath(__file__))

--- a/tests/internal_coordinates/Zmat/test_setitem_lin_ref_detection.py
+++ b/tests/internal_coordinates/Zmat/test_setitem_lin_ref_detection.py
@@ -4,6 +4,13 @@ import pytest
 from chemcoord.exceptions import UndefinedCoordinateSystem, InvalidReference
 import os
 import sys
+import pandas as pd
+
+try:
+    pd.set_option("future.no_silent_downcasting", True)
+except:
+    # Yes I want a bare except
+    pass
 
 
 def get_script_path():

--- a/tests/internal_coordinates/Zmat/test_symb.py
+++ b/tests/internal_coordinates/Zmat/test_symb.py
@@ -4,7 +4,12 @@ import chemcoord as cc
 import sympy
 import pandas as pd
 
-pd.set_option('future.no_silent_downcasting', True)
+try:
+    pd.set_option("future.no_silent_downcasting", True)
+except:
+    # Yes I want a bare except
+    pass
+
 
 def get_script_path():
     return os.path.dirname(os.path.realpath(__file__))

--- a/tests/internal_coordinates/Zmat/test_symb.py
+++ b/tests/internal_coordinates/Zmat/test_symb.py
@@ -2,7 +2,9 @@ import os
 
 import chemcoord as cc
 import sympy
+import pandas as pd
 
+pd.set_option('future.no_silent_downcasting', True)
 
 def get_script_path():
     return os.path.dirname(os.path.realpath(__file__))

--- a/tests/internal_coordinates/Zmat/test_zmat_core.py
+++ b/tests/internal_coordinates/Zmat/test_zmat_core.py
@@ -3,6 +3,7 @@ from os.path import join
 from io import StringIO
 from sympy import Symbol
 import pytest
+import numpy as np
 
 import chemcoord as cc
 from chemcoord.xyz_functions import allclose
@@ -31,6 +32,21 @@ def get_structure_path(script_path):
 
 STRUCTURE_PATH = get_structure_path(get_script_path())
 
+
+def test_assignment():
+    theta, x = Symbol('theta', real=True), Symbol('x', real=True)
+
+    molecule = cc.Cartesian.read_xyz(
+        join(STRUCTURE_PATH, 'MIL53_small.xyz'), start_index=1)
+    zmolecule = molecule.get_zmat()
+
+    zmolecule.safe_loc[:, 'bond'] = x
+    assert zmolecule.bond.dtype == np.dtype('O')
+
+    assert zmolecule.subs(x, 10).bond.dtype == np.dtype('f8')
+
+    with pytest.raises(TypeError):
+        zmolecule.safe_loc[1] = x
 
 def test_addition_with_sympy():
     theta, x = Symbol('theta', real=True), Symbol('x', real=True)

--- a/tests/internal_coordinates/Zmat/test_zmat_core.py
+++ b/tests/internal_coordinates/Zmat/test_zmat_core.py
@@ -45,8 +45,6 @@ def test_assignment():
 
     assert zmolecule.subs(x, 10).bond.dtype == np.dtype('f8')
 
-    with pytest.raises(TypeError):
-        zmolecule.safe_loc[1] = x
 
 def test_addition_with_sympy():
     theta, x = Symbol('theta', real=True), Symbol('x', real=True)

--- a/tests/internal_coordinates/Zmat/test_zmat_core.py
+++ b/tests/internal_coordinates/Zmat/test_zmat_core.py
@@ -8,7 +8,11 @@ import chemcoord as cc
 from chemcoord.xyz_functions import allclose
 import pandas as pd
 
-pd.set_option('future.no_silent_downcasting', True)
+try:
+    pd.set_option("future.no_silent_downcasting", True)
+except:
+    # Yes I want a bare except
+    pass
 
 
 def get_script_path():

--- a/tests/internal_coordinates/Zmat/test_zmat_core.py
+++ b/tests/internal_coordinates/Zmat/test_zmat_core.py
@@ -6,6 +6,9 @@ import pytest
 
 import chemcoord as cc
 from chemcoord.xyz_functions import allclose
+import pandas as pd
+
+pd.set_option('future.no_silent_downcasting', True)
 
 
 def get_script_path():


### PR DESCRIPTION
Replaces deprecated numba `generated_jit` with `overload`

Cleans up many other warnings from pandas and numpy about deprecated behaviour.

Solves #76 