### PR TITLE
Fixed xyz parsing bug #102

### DIFF
--- a/src/chemcoord/cartesian_coordinates/_cartesian_class_io.py
+++ b/src/chemcoord/cartesian_coordinates/_cartesian_class_io.py
@@ -173,6 +173,7 @@ class CartesianIO(CartesianCore, GenericIO):
                             nrows=nrows, sep=r'\s+',
                             names=['atom', 'x', 'y', 'z'], engine=engine)
 
+        # TODO explicitly cast to float
         remove_digits = partial(re.sub, r'[0-9]+', '')
         frame['atom'] = frame['atom'].apply(
             lambda x: remove_digits(x).capitalize())

--- a/src/chemcoord/cartesian_coordinates/_cartesian_class_io.py
+++ b/src/chemcoord/cartesian_coordinates/_cartesian_class_io.py
@@ -174,6 +174,7 @@ class CartesianIO(CartesianCore, GenericIO):
                             names=['atom', 'x', 'y', 'z'], engine=engine)
 
         # TODO explicitly cast to float
+
         remove_digits = partial(re.sub, r'[0-9]+', '')
         frame['atom'] = frame['atom'].apply(
             lambda x: remove_digits(x).capitalize())

--- a/src/chemcoord/cartesian_coordinates/_cartesian_class_io.py
+++ b/src/chemcoord/cartesian_coordinates/_cartesian_class_io.py
@@ -172,9 +172,7 @@ class CartesianIO(CartesianCore, GenericIO):
         frame = pd.read_csv(buf, skiprows=2, comment='#',
                             nrows=nrows, sep=r'\s+',
                             names=['atom', 'x', 'y', 'z'], engine=engine)
-
-        # TODO explicitly cast to float
-
+        frame = frame.astype({'x': float, 'y': float, 'z': float})
         remove_digits = partial(re.sub, r'[0-9]+', '')
         frame['atom'] = frame['atom'].apply(
             lambda x: remove_digits(x).capitalize())

--- a/tests/cartesian_coordinates/Cartesian/test_grad_zmat.py
+++ b/tests/cartesian_coordinates/Cartesian/test_grad_zmat.py
@@ -52,7 +52,7 @@ def test_grad_zmat():
 
     zmat_dist = molecule.get_grad_zmat(c_table)(dist_mol)
 
-    moved_atoms = zmat_dist.index[zmat_dist.loc[:, ['bond', 'angle', 'dihedral']] != 0]
+    moved_atoms = zmat_dist.index[(zmat_dist.loc[:, ['bond', 'angle', 'dihedral']] != 0).any(axis=1)]
 
     assert moved_atoms[0] == 13
     assert (moved_atoms[1:] == c_table.index[(c_table == 13).any(axis=1)]).all()

--- a/tests/cartesian_coordinates/Cartesian/test_grad_zmat.py
+++ b/tests/cartesian_coordinates/Cartesian/test_grad_zmat.py
@@ -52,8 +52,7 @@ def test_grad_zmat():
 
     zmat_dist = molecule.get_grad_zmat(c_table)(dist_mol)
 
-    moved_atoms = zmat_dist.index[
-        (zmat_dist.loc[:, ['bond', 'angle', 'dihedral']] != 0.).any(axis=1)]
+    moved_atoms = zmat_dist.index[zmat_dist.loc[:, ['bond', 'angle', 'dihedral']] != 0]
 
     assert moved_atoms[0] == 13
     assert (moved_atoms[1:] == c_table.index[(c_table == 13).any(axis=1)]).all()

--- a/tests/cartesian_coordinates/Cartesian/test_io.py
+++ b/tests/cartesian_coordinates/Cartesian/test_io.py
@@ -64,9 +64,9 @@ Created by chemcoord http://chemcoord.readthedocs.io/
         assert molecule.write_xyz() in expected
 
 def test_xyz_cast():
-    
+
     molecule_float = cc.Cartesian.read_xyz(get_complete_path('hydrogen_float.xyz'))
-    
+
     molecule_int = cc.Cartesian.read_xyz(get_complete_path('hydrogen_int.xyz'))
 
     assert molecule_int.x.dtype == float

--- a/tests/cartesian_coordinates/Cartesian/test_io.py
+++ b/tests/cartesian_coordinates/Cartesian/test_io.py
@@ -62,3 +62,13 @@ Created by chemcoord http://chemcoord.readthedocs.io/
 
     with pytest.warns(DeprecationWarning):
         assert molecule.write_xyz() in expected
+
+def test_xyz_cast():
+    
+    molecule_float = cc.Cartesian.read_xyz(get_complete_path('hydrogen_float.xyz'))
+    
+    molecule_int = cc.Cartesian.read_xyz(get_complete_path('hydrogen_int.xyz'))
+
+    assert molecule_int.x.dtype == float
+
+    assert allclose(molecule_float, molecule_int)

--- a/tests/structures/hydrogen_float.xyz
+++ b/tests/structures/hydrogen_float.xyz
@@ -1,0 +1,4 @@
+2
+Created by chemcoord http://chemcoord.readthedocs.io/en/latest/
+H 0.000000 0.000000  0.000000
+H 1.000000 0.000000  0.000000

--- a/tests/structures/hydrogen_int.xyz
+++ b/tests/structures/hydrogen_int.xyz
@@ -1,0 +1,4 @@
+2
+Created by chemcoord http://chemcoord.readthedocs.io/en/latest/
+H 0 0 0
+H 1 0 0


### PR DESCRIPTION
Explicitly cast position values read from .xyz files to floats as some contained integer values. Now, positions read from .xyz files are guaranteed to be read as floats.