### PR TITLE
Use numpy functions

### DIFF
--- a/src/chemcoord/_cartesian_coordinates/_cart_transformation.py
+++ b/src/chemcoord/_cartesian_coordinates/_cart_transformation.py
@@ -6,7 +6,7 @@ from numpy import arccos, arctan2, sqrt
 
 import chemcoord.constants as constants
 from chemcoord._cartesian_coordinates.xyz_functions import (
-    normalize,
+    _jit_normalize,
 )
 from chemcoord.exceptions import ERR_CODE_OK, ERR_CODE_InvalidReference
 
@@ -57,11 +57,11 @@ def get_B(X, c_table, j):
     if np.allclose(BA, 0.0):
         return (ERR_CODE_InvalidReference, B)
     AD = ref_pos[:, 2] - ref_pos[:, 1]
-    B[:, 2] = -normalize(BA)
+    B[:, 2] = -_jit_normalize(BA)
     N = np.cross(AD, BA)
     if np.allclose(N, 0.0):
         return (ERR_CODE_InvalidReference, B)
-    B[:, 1] = normalize(N)
+    B[:, 1] = _jit_normalize(N)
     B[:, 0] = np.cross(B[:, 1], B[:, 2])
     return (ERR_CODE_OK, B)
 

--- a/src/chemcoord/_cartesian_coordinates/_cart_transformation.py
+++ b/src/chemcoord/_cartesian_coordinates/_cart_transformation.py
@@ -6,7 +6,7 @@ from numpy import arccos, arctan2, sqrt
 
 import chemcoord.constants as constants
 from chemcoord._cartesian_coordinates.xyz_functions import (
-    _jit_normalize,
+    normalize,
 )
 from chemcoord.exceptions import ERR_CODE_OK, ERR_CODE_InvalidReference
 
@@ -57,11 +57,11 @@ def get_B(X, c_table, j):
     if np.allclose(BA, 0.0):
         return (ERR_CODE_InvalidReference, B)
     AD = ref_pos[:, 2] - ref_pos[:, 1]
-    B[:, 2] = -_jit_normalize(BA)
+    B[:, 2] = -normalize(BA)
     N = np.cross(AD, BA)
     if np.allclose(N, 0.0):
         return (ERR_CODE_InvalidReference, B)
-    B[:, 1] = _jit_normalize(N)
+    B[:, 1] = normalize(N)
     B[:, 0] = np.cross(B[:, 1], B[:, 2])
     return (ERR_CODE_OK, B)
 

--- a/src/chemcoord/_cartesian_coordinates/_cart_transformation.py
+++ b/src/chemcoord/_cartesian_coordinates/_cart_transformation.py
@@ -6,7 +6,6 @@ from numpy import arccos, arctan2, sqrt
 
 import chemcoord.constants as constants
 from chemcoord._cartesian_coordinates.xyz_functions import (
-    _jit_cross,
     _jit_isclose,
     _jit_normalize,
 )
@@ -60,11 +59,11 @@ def get_B(X, c_table, j):
         return (ERR_CODE_InvalidReference, B)
     AD = ref_pos[:, 2] - ref_pos[:, 1]
     B[:, 2] = -_jit_normalize(BA)
-    N = _jit_cross(AD, BA)
+    N = np.cross(AD, BA)
     if _jit_isclose(N, 0.0).all():
         return (ERR_CODE_InvalidReference, B)
     B[:, 1] = _jit_normalize(N)
-    B[:, 0] = _jit_cross(B[:, 1], B[:, 2])
+    B[:, 0] = np.cross(B[:, 1], B[:, 2])
     return (ERR_CODE_OK, B)
 
 
@@ -77,7 +76,7 @@ def get_grad_B(X, c_table, j):
     x_a, y_a, z_a = v_a
     x_d, y_d, z_d = v_d
     BA, AD = v_a - v_b, v_d - v_a
-    norm_AD_cross_BA = np.linalg.norm(_jit_cross(AD, BA))
+    norm_AD_cross_BA = np.linalg.norm(np.cross(AD, BA))
     norm_BA = np.linalg.norm(BA)
     grad_B[0, 0, 0, 0] = (
         (x_a - x_b)

--- a/src/chemcoord/_cartesian_coordinates/_cart_transformation.py
+++ b/src/chemcoord/_cartesian_coordinates/_cart_transformation.py
@@ -6,7 +6,6 @@ from numpy import arccos, arctan2, sqrt
 
 import chemcoord.constants as constants
 from chemcoord._cartesian_coordinates.xyz_functions import (
-    _jit_isclose,
     _jit_normalize,
 )
 from chemcoord.exceptions import ERR_CODE_OK, ERR_CODE_InvalidReference
@@ -55,12 +54,12 @@ def get_B(X, c_table, j):
     B = np.empty((3, 3))
     ref_pos = get_ref_pos(X, c_table[:, j])
     BA = ref_pos[:, 1] - ref_pos[:, 0]
-    if _jit_isclose(BA, 0.0).all():
+    if np.allclose(BA, 0.0):
         return (ERR_CODE_InvalidReference, B)
     AD = ref_pos[:, 2] - ref_pos[:, 1]
     B[:, 2] = -_jit_normalize(BA)
     N = np.cross(AD, BA)
-    if _jit_isclose(N, 0.0).all():
+    if np.allclose(N, 0.0):
         return (ERR_CODE_InvalidReference, B)
     B[:, 1] = _jit_normalize(N)
     B[:, 0] = np.cross(B[:, 1], B[:, 2])
@@ -1106,9 +1105,9 @@ def get_grad_S_inv(v):
     grad_S_inv = np.zeros((3, 3))
 
     r = np.linalg.norm(v)
-    if _jit_isclose(r, 0):
+    if np.isclose(r, 0):
         pass
-    elif _jit_isclose(x**2 + y**2, 0):
+    elif np.isclose(x**2 + y**2, 0):
         grad_S_inv[0, 0] = 0.0
         grad_S_inv[0, 1] = 0.0
         grad_S_inv[0, 2] = 1

--- a/src/chemcoord/_cartesian_coordinates/xyz_functions.py
+++ b/src/chemcoord/_cartesian_coordinates/xyz_functions.py
@@ -293,8 +293,14 @@ def concat(cartesians, ignore_index=False, keys=None):
     return cartesians[0].__class__(new)
 
 
-@jit(nopython=True, cache=True)
 def normalize(vector):
+    """Normalizes a vector"""
+    normed_vector = vector / np.linalg.norm(vector)
+    return normed_vector
+
+
+@jit(nopython=True, cache=True)
+def _jit_normalize(vector):
     """Normalizes a vector"""
     normed_vector = vector / np.linalg.norm(vector)
     return normed_vector
@@ -336,7 +342,7 @@ def _jit_get_rotation_matrix(axis, angle):
     Returns:
         Rotation matrix (np.array):
     """
-    axis = normalize(axis)
+    axis = _jit_normalize(axis)
     a = m.cos(angle / 2)
     b, c, d = axis * m.sin(angle / 2)
     rot_matrix = np.empty((3, 3))

--- a/src/chemcoord/_cartesian_coordinates/xyz_functions.py
+++ b/src/chemcoord/_cartesian_coordinates/xyz_functions.py
@@ -293,14 +293,8 @@ def concat(cartesians, ignore_index=False, keys=None):
     return cartesians[0].__class__(new)
 
 
-def normalize(vector):
-    """Normalizes a vector"""
-    normed_vector = vector / np.linalg.norm(vector)
-    return normed_vector
-
-
 @jit(nopython=True, cache=True)
-def _jit_normalize(vector):
+def normalize(vector):
     """Normalizes a vector"""
     normed_vector = vector / np.linalg.norm(vector)
     return normed_vector
@@ -342,7 +336,7 @@ def _jit_get_rotation_matrix(axis, angle):
     Returns:
         Rotation matrix (np.array):
     """
-    axis = _jit_normalize(axis)
+    axis = normalize(axis)
     a = m.cos(angle / 2)
     b, c, d = axis * m.sin(angle / 2)
     rot_matrix = np.empty((3, 3))

--- a/src/chemcoord/_cartesian_coordinates/xyz_functions.py
+++ b/src/chemcoord/_cartesian_coordinates/xyz_functions.py
@@ -294,11 +294,6 @@ def concat(cartesians, ignore_index=False, keys=None):
 
 
 @jit(nopython=True, cache=True)
-def _jit_isclose(a, b, atol=1e-5, rtol=1e-8):
-    return np.abs(a - b) <= (atol + rtol * np.abs(b))
-
-
-@jit(nopython=True, cache=True)
 def _jit_allclose(a, b, atol=1e-5, rtol=1e-8):
     n, m = a.shape
     for i in range(n):

--- a/src/chemcoord/_cartesian_coordinates/xyz_functions.py
+++ b/src/chemcoord/_cartesian_coordinates/xyz_functions.py
@@ -5,7 +5,6 @@ import tempfile
 import warnings
 from threading import Thread
 
-import numba as nb
 import numpy as np
 import pandas as pd
 import sympy
@@ -307,15 +306,6 @@ def _jit_allclose(a, b, atol=1e-5, rtol=1e-8):
             if np.abs(a[i, j] - b[i, j]) > (atol + rtol * np.abs(b[i, j])):
                 return False
     return True
-
-
-@jit(nb.f8[:](nb.f8[:], nb.f8[:]), nopython=True)
-def _jit_cross(A, B):
-    C = np.empty_like(A)
-    C[0] = A[1] * B[2] - A[2] * B[1]
-    C[1] = A[2] * B[0] - A[0] * B[2]
-    C[2] = A[0] * B[1] - A[1] * B[0]
-    return C
 
 
 def normalize(vector):

--- a/src/chemcoord/_cartesian_coordinates/xyz_functions.py
+++ b/src/chemcoord/_cartesian_coordinates/xyz_functions.py
@@ -293,16 +293,6 @@ def concat(cartesians, ignore_index=False, keys=None):
     return cartesians[0].__class__(new)
 
 
-@jit(nopython=True, cache=True)
-def _jit_allclose(a, b, atol=1e-5, rtol=1e-8):
-    n, m = a.shape
-    for i in range(n):
-        for j in range(m):
-            if np.abs(a[i, j] - b[i, j]) > (atol + rtol * np.abs(b[i, j])):
-                return False
-    return True
-
-
 def normalize(vector):
     """Normalizes a vector"""
     normed_vector = vector / np.linalg.norm(vector)

--- a/src/chemcoord/_internal_coordinates/_zmat_transformation.py
+++ b/src/chemcoord/_internal_coordinates/_zmat_transformation.py
@@ -18,7 +18,6 @@ from chemcoord._cartesian_coordinates._cart_transformation import (
     get_grad_B,
     get_ref_pos,
 )
-from chemcoord._cartesian_coordinates.xyz_functions import _jit_isclose
 from chemcoord.exceptions import ERR_CODE_OK, ERR_CODE_InvalidReference
 
 
@@ -26,9 +25,9 @@ from chemcoord.exceptions import ERR_CODE_OK, ERR_CODE_InvalidReference
 def get_S(C, j):
     S = np.zeros(3)
     r, alpha, delta = C[:, j]
-    if _jit_isclose(alpha, np.pi):
+    if np.isclose(alpha, np.pi):
         S[2] = r
-    elif _jit_isclose(alpha, 0):
+    elif np.isclose(alpha, 0):
         S[2] = -r
     else:
         S[0] = r * sin(alpha) * cos(delta)


### PR DESCRIPTION
There are a few numpy functions such as `numpy.cross` which were not available for numba when I wrote the package.
With this PR the corresponding numpy functions are used instead of the custom ones.

Fixes #113 