### PR TITLE
Small fixes

### DIFF
--- a/docs/source/src_AsymmetricUnitCartesian/chemcoord.AsymmetricUnitCartesian.rst
+++ b/docs/source/src_AsymmetricUnitCartesian/chemcoord.AsymmetricUnitCartesian.rst
@@ -30,6 +30,7 @@
       ~AsymmetricUnitCartesian.fragmentate
       ~AsymmetricUnitCartesian.from_ase_atoms
       ~AsymmetricUnitCartesian.from_pymatgen_molecule
+      ~AsymmetricUnitCartesian.from_pyscf
       ~AsymmetricUnitCartesian.get_align_transf
       ~AsymmetricUnitCartesian.get_angle_degrees
       ~AsymmetricUnitCartesian.get_ase_atoms
@@ -70,6 +71,7 @@
       ~AsymmetricUnitCartesian.symmetrize
       ~AsymmetricUnitCartesian.to_cjson
       ~AsymmetricUnitCartesian.to_latex
+      ~AsymmetricUnitCartesian.to_pyscf
       ~AsymmetricUnitCartesian.to_string
       ~AsymmetricUnitCartesian.to_xyz
       ~AsymmetricUnitCartesian.to_zmat

--- a/docs/source/src_Cartesian/chemcoord.Cartesian.rst
+++ b/docs/source/src_Cartesian/chemcoord.Cartesian.rst
@@ -30,6 +30,7 @@
       ~Cartesian.fragmentate
       ~Cartesian.from_ase_atoms
       ~Cartesian.from_pymatgen_molecule
+      ~Cartesian.from_pyscf
       ~Cartesian.get_align_transf
       ~Cartesian.get_angle_degrees
       ~Cartesian.get_ase_atoms
@@ -69,6 +70,7 @@
       ~Cartesian.symmetrize
       ~Cartesian.to_cjson
       ~Cartesian.to_latex
+      ~Cartesian.to_pyscf
       ~Cartesian.to_string
       ~Cartesian.to_xyz
       ~Cartesian.to_zmat

--- a/docs/source/src_Cartesian/src_Cartesian/chemcoord.Cartesian.from_pyscf.rst
+++ b/docs/source/src_Cartesian/src_Cartesian/chemcoord.Cartesian.from_pyscf.rst
@@ -1,0 +1,8 @@
+﻿:orphan:
+
+chemcoord.Cartesian.from\_pyscf
+====================================
+
+.. currentmodule:: chemcoord
+
+.. automethod:: Cartesian.from_pyscf

--- a/docs/source/src_Cartesian/src_Cartesian/chemcoord.Cartesian.to_pyscf.rst
+++ b/docs/source/src_Cartesian/src_Cartesian/chemcoord.Cartesian.to_pyscf.rst
@@ -1,0 +1,8 @@
+﻿:orphan:
+
+chemcoord.Cartesian.to\_pyscf
+===========================
+
+.. currentmodule:: chemcoord
+
+.. automethod:: Cartesian.to_pyscf

--- a/src/chemcoord/_cartesian_coordinates/_cart_transformation.py
+++ b/src/chemcoord/_cartesian_coordinates/_cart_transformation.py
@@ -1095,7 +1095,7 @@ def get_S_inv(v):
     if r == 0:
         return np.array([0.0, 0.0, 0.0])
     alpha = arccos(-z / r)
-    delta = arctan2(-y / r, x / r)
+    delta = arctan2(-y, x)
     return np.array([r, alpha, delta])
 
 

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
@@ -268,7 +268,7 @@ class CartesianIO(CartesianCore, GenericIO):
         return molecule
 
     @classmethod
-    def from_pyscf_molecule(cls, mol):
+    def from_pyscf(cls, mol):
         """Create an instance of the own class from a PySCF molecule
 
         Args:

--- a/tests/cartesian_coordinates/Cartesian/test_io.py
+++ b/tests/cartesian_coordinates/Cartesian/test_io.py
@@ -74,4 +74,4 @@ def test_xyz_cast():
 
 def test_pyscf_conversion():
     m = Cartesian.read_xyz(get_complete_path("water.xyz"))
-    assert allclose(Cartesian.from_pyscf_molecule(m.to_pyscf()), m)
+    assert allclose(Cartesian.from_pyscf(m.to_pyscf()), m)


### PR DESCRIPTION
- use `arctan(x, y) == arctan(x / r,  y / r)` for non-zero r and get rid of unnecessary division. Spotted by @nwhel 
- added missing rst files for the new pyscf conversion methods.