### PR TITLE
Type hinting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,10 +37,6 @@ run_tests: &run_tests
           name: Running tests
           command: python3 -m pytest -Werror --cov=./src/chemcoord tests/
       - run:
-          name: Upload coverage reports to Codecov
-          command: |
-            bash <(curl -s https://codecov.io/bash)
-      - run:
           name: Prepare documentation
           command: pip3 install -r docs/requirements.txt
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ cealign-0.8-RBS
 #pytest
 *.chache/*
 .cache/
+
+
+.mypy_cache/

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ INSTALL_REQUIRES = [
     "sympy",
     "six",
     "pymatgen",
+    "typing_extensions",
 ]
 KEYWORDS = [
     "chemcoord",

--- a/src/chemcoord/_cartesian_coordinates/_cart_transformation.py
+++ b/src/chemcoord/_cartesian_coordinates/_cart_transformation.py
@@ -1,6 +1,5 @@
 import numba as nb
 import numpy as np
-from numba import njit
 from numba.extending import overload
 from numpy import arccos, arctan2, sqrt
 
@@ -8,6 +7,7 @@ import chemcoord.constants as constants
 from chemcoord._cartesian_coordinates.xyz_functions import (
     _jit_normalize,
 )
+from chemcoord._utilities._decorators import njit
 from chemcoord.exceptions import ERR_CODE_OK, ERR_CODE_InvalidReference
 
 
@@ -44,12 +44,12 @@ def _get_ref_pos_impl(X, indices):  # noqa: ARG001
         raise AssertionError("Should not be here")
 
 
-@njit(cache=True)
+@njit
 def get_ref_pos(X, indices):
     return _stub_get_ref_pos(X, indices)
 
 
-@njit(cache=True)
+@njit
 def get_B(X, c_table, j):
     B = np.empty((3, 3))
     ref_pos = get_ref_pos(X, c_table[:, j])
@@ -66,7 +66,7 @@ def get_B(X, c_table, j):
     return (ERR_CODE_OK, B)
 
 
-@njit(cache=True)
+@njit
 def get_grad_B(X, c_table, j):
     grad_B = np.empty((3, 3, 3, 3))
     ref_pos = get_ref_pos(X, c_table[:, j])
@@ -1130,7 +1130,7 @@ def get_grad_S_inv(v):
     return grad_S_inv
 
 
-@njit(cache=True)
+@njit
 def get_T(X, c_table, j):
     err, B = get_B(X, c_table, j)
     if err == ERR_CODE_OK:
@@ -1141,7 +1141,7 @@ def get_T(X, c_table, j):
     return err, result
 
 
-@njit(cache=True)
+@njit
 def get_C(X, c_table):
     C = np.empty((3, c_table.shape[1]))
 
@@ -1154,7 +1154,7 @@ def get_C(X, c_table):
     return (ERR_CODE_OK, C)
 
 
-@njit(cache=True)
+@njit
 def get_grad_C(X, c_table):
     n_atoms = X.shape[1]
     grad_C = np.zeros((3, n_atoms, n_atoms, 3))

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
@@ -114,10 +114,10 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             )
             raise PhysicalMeaning(message)
 
-    def __add__(self, other: ArithmeticOther) -> Self:
+    def __add__(self, other: Union[Self, ArithmeticOther]) -> Self:
         coords = ["x", "y", "z"]
         new = self.copy()
-        if isinstance(other, CartesianCore):
+        if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
             new.loc[:, coords] = self.loc[:, coords] + other.loc[:, coords]
         elif isinstance(other, DataFrame):
@@ -130,13 +130,13 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             new.loc[:, coords] = self.loc[:, coords] + other
         return new
 
-    def __radd__(self, other: ArithmeticOther) -> Self:
+    def __radd__(self, other: Union[Self, ArithmeticOther]) -> Self:
         return self.__add__(other)
 
-    def __sub__(self, other: ArithmeticOther) -> Self:
+    def __sub__(self, other: Union[Self, ArithmeticOther]) -> Self:
         coords = ["x", "y", "z"]
         new = self.copy()
-        if isinstance(other, CartesianCore):
+        if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
             new.loc[:, coords] = self.loc[:, coords] - other.loc[:, coords]
         elif isinstance(other, DataFrame):
@@ -149,10 +149,10 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             new.loc[:, coords] = self.loc[:, coords] - other
         return new
 
-    def __rsub__(self, other: ArithmeticOther) -> Self:
+    def __rsub__(self, other: Union[Self, ArithmeticOther]) -> Self:
         coords = ["x", "y", "z"]
         new = self.copy()
-        if isinstance(other, CartesianCore):
+        if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
             new.loc[:, coords] = other.loc[:, coords] - self.loc[:, coords]
         elif isinstance(other, DataFrame):
@@ -165,10 +165,10 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             new.loc[:, coords] = other - self.loc[:, coords]
         return new
 
-    def __mul__(self, other: ArithmeticOther) -> Self:
+    def __mul__(self, other: Union[Self, ArithmeticOther]) -> Self:
         coords = ["x", "y", "z"]
         new = self.copy()
-        if isinstance(other, CartesianCore):
+        if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
             new.loc[:, coords] = self.loc[:, coords] * other.loc[:, coords]
         elif isinstance(other, DataFrame):
@@ -181,13 +181,13 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             new.loc[:, coords] = self.loc[:, coords] * other
         return new
 
-    def __rmul__(self, other: ArithmeticOther) -> Self:
+    def __rmul__(self, other: Union[Self, ArithmeticOther]) -> Self:
         return self.__mul__(other)
 
-    def __truediv__(self, other: ArithmeticOther) -> Self:
+    def __truediv__(self, other: Union[Self, ArithmeticOther]) -> Self:
         coords = ["x", "y", "z"]
         new = self.copy()
-        if isinstance(other, CartesianCore):
+        if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
             new.loc[:, coords] = self.loc[:, coords] / other.loc[:, coords]
         elif isinstance(other, DataFrame):
@@ -200,10 +200,10 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             new.loc[:, coords] = self.loc[:, coords] / other
         return new
 
-    def __rtruediv__(self, other: ArithmeticOther) -> Self:
+    def __rtruediv__(self, other: Union[Self, ArithmeticOther]) -> Self:
         coords = ["x", "y", "z"]
         new = self.copy()
-        if isinstance(other, CartesianCore):
+        if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
             new.loc[:, coords] = other.loc[:, coords] / self.loc[:, coords]
         elif isinstance(other, DataFrame):
@@ -216,7 +216,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             new.loc[:, coords] = other / self.loc[:, coords]
         return new
 
-    def __pow__(self, other: ArithmeticOther) -> Self:
+    def __pow__(self, other: Union[Self, ArithmeticOther]) -> Self:
         coords = ["x", "y", "z"]
         new = self.copy()
         new.loc[:, coords] = self.loc[:, coords] ** other

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
@@ -8,7 +8,6 @@ from typing import Any
 import numba as nb
 import numpy as np
 import pandas as pd
-from numba import njit
 from pandas import DataFrame, Series
 from sortedcontainers import SortedSet
 from typing_extensions import Self
@@ -19,6 +18,7 @@ from chemcoord._cartesian_coordinates._cartesian_class_pandas_wrapper import (
     PandasWrapper,
 )
 from chemcoord._generic_classes.generic_core import GenericCore
+from chemcoord._utilities._decorators import njit
 from chemcoord._utilities.typing import ArithmeticOther, Axes, Matrix
 from chemcoord.configuration import settings
 from chemcoord.exceptions import PhysicalMeaning
@@ -53,6 +53,8 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         Returns:
             Cartesian: A new cartesian instance.
         """
+        if not isinstance(frame, DataFrame):
+            raise TypeError("frame has to be a pandas DataFrame")
         if not self._required_cols <= set(frame.columns):
             raise PhysicalMeaning(
                 "There are columns missing for a meaningful description of a molecule"
@@ -303,7 +305,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         return out
 
     @staticmethod
-    @njit(cache=True)
+    @njit
     def _jit_give_bond_array(pos, bond_radii, self_bonding_allowed=False):
         """Calculate a boolean array where ``A[i,j] is True`` indicates a
         bond between the i-th and j-th atom.
@@ -987,7 +989,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         return sorted(missing_part, key=len, reverse=True)
 
     @staticmethod
-    @njit(cache=True)
+    @njit
     def _jit_pairwise_distances(pos1, pos2):
         """Optimized function for calculating the distance between each pair
         of points in positions1 and positions2.

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
@@ -1,6 +1,7 @@
 import collections
 import copy
 import itertools
+from collections.abc import Sequence
 from itertools import product
 
 import numba as nb
@@ -29,13 +30,13 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
     # overwrites existing method
     def __init__(
         self,
-        frame=None,
-        atoms=None,
-        coords=None,
-        index=None,
-        metadata=None,
-        _metadata=None,
-    ):
+        frame: pd.DataFrame | None = None,
+        atoms: Sequence[str] | None = None,
+        coords: dict | None = None,
+        index: dict | None = None,
+        metadata: dict | None = None,
+        _metadata: dict | None = None,
+    ) -> None:
         """How to initialize a Cartesian instance.
 
         Args:

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
@@ -3,7 +3,7 @@ import copy
 import itertools
 from collections.abc import Sequence
 from itertools import product
-from typing import Any
+from typing import Any, Union
 
 import numba as nb
 import numpy as np
@@ -35,8 +35,8 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
     def __init__(
         self,
         frame: DataFrame,
-        metadata: dict | None = None,
-        _metadata: dict | None = None,
+        metadata: Union[dict, None] = None,
+        _metadata: Union[dict, None] = None,
     ) -> None:
         """How to initialize a Cartesian instance.
 
@@ -75,7 +75,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         cls,
         atoms: Sequence[str],
         coords: Matrix,
-        index: Axes | None = None,
+        index: Union[Axes, None] = None,
     ) -> Self:
         dtypes = [("atom", str), ("x", float), ("y", float), ("z", float)]
         frame = DataFrame(np.empty(len(atoms), dtype=dtypes), index=index)
@@ -84,8 +84,8 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         return cls(frame)
 
     def _return_appropiate_type(
-        self, selected: Series | DataFrame
-    ) -> Self | Series | DataFrame:
+        self, selected: Union[Series, DataFrame]
+    ) -> Union[Self, Series, DataFrame]:
         if isinstance(selected, Series):
             frame = DataFrame(selected).T
             if self._required_cols <= set(frame.columns):

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
@@ -19,7 +19,7 @@ from chemcoord._cartesian_coordinates._cartesian_class_pandas_wrapper import (
 )
 from chemcoord._generic_classes.generic_core import GenericCore
 from chemcoord._utilities._decorators import njit
-from chemcoord._utilities.typing import ArithmeticOther, Axes, Matrix
+from chemcoord._utilities.typing import ArithmeticOther, Axes, Matrix, Vector
 from chemcoord.configuration import settings
 from chemcoord.exceptions import PhysicalMeaning
 
@@ -306,7 +306,11 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
 
     @staticmethod
     @njit
-    def _jit_give_bond_array(pos, bond_radii, self_bonding_allowed=False):
+    def _jit_give_bond_array(
+        pos: Matrix[np.floating],
+        bond_radii: Vector[np.floating],
+        self_bonding_allowed: bool = False,
+    ) -> Matrix[np.float64]:
         """Calculate a boolean array where ``A[i,j] is True`` indicates a
         bond between the i-th and j-th atom.
         """

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
@@ -31,7 +31,6 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
     # https://docs.scipy.org/doc/numpy-1.12.0/reference/arrays.classes.html
     __array_priority__ = 15.0
 
-    # overwrites existing method
     def __init__(
         self,
         frame: DataFrame,

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
@@ -241,6 +241,9 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         new.loc[:, coords] = (np.dot(other, new.loc[:, coords].T)).T
         return new
 
+    # Somehow the base class `object` expects the return type to be `bool``
+    #  but the correct type hint is DataFrame.
+    # Ignore this override error.
     def __eq__(self, other: Self) -> DataFrame:  # type: ignore[override]
         return self._frame == other._frame
 

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
@@ -31,6 +31,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
     # https://docs.scipy.org/doc/numpy-1.12.0/reference/arrays.classes.html
     __array_priority__ = 15.0
 
+    # overwrites existing method
     def __init__(
         self,
         frame: DataFrame,

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
@@ -277,7 +277,7 @@ class CartesianIO(CartesianCore, GenericIO):
         Returns:
             Cartesian:
         """
-        return cls(
+        return cls.set_atom_coords(
             atoms=mol.elements,
             coords=mol.atom_coords(unit="Angstrom"),
         )
@@ -458,7 +458,7 @@ class CartesianIO(CartesianCore, GenericIO):
         Returns:
             Cartesian:
         """
-        return cls(
+        return cls.set_atom_coords(
             atoms=[el.value for el in molecule.species], coords=molecule.cart_coords
         )
 

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_pandas_wrapper.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_pandas_wrapper.py
@@ -4,7 +4,7 @@ import chemcoord._cartesian_coordinates._indexers as indexers
 from chemcoord.exceptions import PhysicalMeaning
 
 
-class PandasWrapper(object):
+class PandasWrapper:
     """This class provides wrappers for :class:`pandas.DataFrame` methods.
 
     It has the same behaviour as the :class:`~pandas.DataFrame`

--- a/src/chemcoord/_cartesian_coordinates/_indexers.py
+++ b/src/chemcoord/_cartesian_coordinates/_indexers.py
@@ -3,7 +3,7 @@ import warnings
 from chemcoord._utilities._temporary_deprecation_workarounds import is_iterable
 
 
-class _generic_Indexer(object):
+class _generic_Indexer:
     def __init__(self, molecule):
         self.molecule = molecule
 

--- a/src/chemcoord/_cartesian_coordinates/xyz_functions.py
+++ b/src/chemcoord/_cartesian_coordinates/xyz_functions.py
@@ -8,8 +8,8 @@ from threading import Thread
 import numpy as np
 import pandas as pd
 import sympy
-from numba import njit
 
+from chemcoord._utilities._decorators import njit
 from chemcoord.configuration import settings
 
 
@@ -299,7 +299,7 @@ def normalize(vector):
     return normed_vector
 
 
-@njit(cache=True)
+@njit
 def _jit_normalize(vector):
     """Normalizes a vector"""
     normed_vector = vector / np.linalg.norm(vector)
@@ -327,7 +327,7 @@ def get_rotation_matrix(axis, angle):
     return _jit_get_rotation_matrix(axis, angle)
 
 
-@njit(cache=True)
+@njit
 def _jit_get_rotation_matrix(axis, angle):
     """Returns the rotation matrix.
 

--- a/src/chemcoord/_generic_classes/generic_IO.py
+++ b/src/chemcoord/_generic_classes/generic_IO.py
@@ -2,7 +2,7 @@ import numpy as np
 import sympy
 
 
-class GenericIO(object):
+class GenericIO:
     def _sympy_formatter(self):
         def formatter(x):
             if isinstance(x, sympy.Basic):

--- a/src/chemcoord/_generic_classes/generic_core.py
+++ b/src/chemcoord/_generic_classes/generic_core.py
@@ -3,7 +3,7 @@ import pandas as pd
 import chemcoord.constants as constants
 
 
-class GenericCore(object):
+class GenericCore:
     def add_data(self, new_cols=None):
         """Adds a column with the requested data.
 

--- a/src/chemcoord/_internal_coordinates/_indexers.py
+++ b/src/chemcoord/_internal_coordinates/_indexers.py
@@ -4,7 +4,7 @@ from chemcoord._utilities._temporary_deprecation_workarounds import is_iterable
 from chemcoord.exceptions import InvalidReference
 
 
-class _generic_Indexer(object):
+class _generic_Indexer:
     def __init__(self, molecule):
         self.molecule = molecule
 

--- a/src/chemcoord/_internal_coordinates/_zmat_class_pandas_wrapper.py
+++ b/src/chemcoord/_internal_coordinates/_zmat_class_pandas_wrapper.py
@@ -1,4 +1,4 @@
-class PandasWrapper(object):
+class PandasWrapper:
     """This class provides wrappers for :class:`pandas.DataFrame` methods.
 
     It has the same behaviour as the :class:`~pandas.DataFrame`

--- a/src/chemcoord/_internal_coordinates/_zmat_transformation.py
+++ b/src/chemcoord/_internal_coordinates/_zmat_transformation.py
@@ -1,6 +1,6 @@
 import numba as nb
 import numpy as np
-from numba import njit, prange
+from numba import prange
 from numpy import cos, cross, sin
 from numpy.linalg import inv
 
@@ -10,10 +10,11 @@ from chemcoord._cartesian_coordinates._cart_transformation import (
     get_grad_B,
     get_ref_pos,
 )
+from chemcoord._utilities._decorators import njit
 from chemcoord.exceptions import ERR_CODE_OK, ERR_CODE_InvalidReference
 
 
-@njit(cache=True)
+@njit
 def get_S(C, j):
     S = np.zeros(3)
     r, alpha, delta = C[:, j]
@@ -28,7 +29,7 @@ def get_S(C, j):
     return S
 
 
-@njit(cache=True)
+@njit
 def get_grad_S(C, j):
     grad_S = np.empty((3, 3), dtype=nb.f8)
     r, alpha, delta = C[:, j]
@@ -50,7 +51,7 @@ def get_grad_S(C, j):
     return grad_S
 
 
-@njit(cache=True)
+@njit
 def get_X(C, c_table):
     X = np.empty_like(C)
     n_atoms = X.shape[1]
@@ -62,7 +63,7 @@ def get_X(C, c_table):
     return (ERR_CODE_OK, j, X)  # pylint:disable=undefined-loop-variable
 
 
-@njit(cache=True)
+@njit
 def chain_grad(X, grad_X, C, c_table, j, l):
     """Chain the gradients.
 
@@ -114,7 +115,7 @@ def chain_grad(X, grad_X, C, c_table, j, l):
     return new_grad_X
 
 
-@njit(cache=True)
+@njit
 def get_grad_X(C, c_table, chain=True):
     n_atoms = C.shape[1]
     grad_X = np.zeros((3, n_atoms, n_atoms, 3))
@@ -127,14 +128,14 @@ def get_grad_X(C, c_table, chain=True):
     return grad_X
 
 
-@njit(cache=True)
+@njit
 def to_barycenter(X, masses):
     M = masses.sum()
     v = (X * masses).sum(axis=1).reshape((3, 1)) / M
     return X - v
 
 
-@njit(parallel=True, cache=True)
+@njit(parallel=True)
 def remove_translation(grad_X, masses):
     clean_grad_X = np.empty_like(grad_X)
     n_atoms = grad_X.shape[1]
@@ -144,7 +145,7 @@ def remove_translation(grad_X, masses):
     return clean_grad_X
 
 
-@njit(parallel=True, cache=True)
+@njit(parallel=True)
 def pure_internal_grad(X, grad_X, masses, theta):
     """Return a gradient for the transformation to X
     that only contains internal degrees of freedom

--- a/src/chemcoord/_internal_coordinates/zmat_functions.py
+++ b/src/chemcoord/_internal_coordinates/zmat_functions.py
@@ -122,4 +122,6 @@ def apply_grad_cartesian_tensor(grad_X, zmat_dist):
         Cartesian,
     )
 
-    return Cartesian(atoms=zmat_dist["atom"], coords=cart_dist, index=zmat_dist.index)
+    return Cartesian.set_atom_coords(
+        atoms=zmat_dist["atom"], coords=cart_dist, index=zmat_dist.index
+    )

--- a/src/chemcoord/_internal_coordinates/zmat_functions.py
+++ b/src/chemcoord/_internal_coordinates/zmat_functions.py
@@ -4,7 +4,7 @@ import sympy
 from chemcoord._internal_coordinates.zmat_class_main import Zmat
 
 
-class DummyManipulation(object):
+class DummyManipulation:
     """Contextmanager that controls the behaviour of
     :meth:`~chemcoord.Zmat.safe_loc` and
     :meth:`~chemcoord.Zmat.safe_iloc`.
@@ -41,7 +41,7 @@ class DummyManipulation(object):
         self.cls.dummy_manipulation_allowed = self.old_value
 
 
-class TestOperators(object):
+class TestOperators:
     """Switch the validity testing of zmatrices resulting from operators.
 
     The following examples is done with ``+``
@@ -67,7 +67,7 @@ class TestOperators(object):
         self.cls.test_operators = self.old_value
 
 
-class PureInternalMovement(object):
+class PureInternalMovement:
     """Remove the translational and rotational degrees of freedom.
 
     When doing assignments to the z-matrix::

--- a/src/chemcoord/_utilities/_decorators.py
+++ b/src/chemcoord/_utilities/_decorators.py
@@ -2,7 +2,7 @@
 # and modified. http://pandas.pydata.org/
 from collections.abc import Callable
 from textwrap import dedent
-from typing import TypeVar, overload
+from typing import TypeVar, Union, overload
 
 import numba as nb
 
@@ -119,8 +119,8 @@ def njit(**kwargs) -> Callable[[Function], Function]: ...
 
 
 def njit(
-    f: Function | None = None, **kwargs
-) -> Function | Callable[[Function], Function]:
+    f: Union[Function, None] = None, **kwargs
+) -> Union[Function, Callable[[Function], Function]]:
     """Type-safe jit wrapper that caches the compiled function
 
     With this jit wrapper, you can actually use static typing together with numba.

--- a/src/chemcoord/_utilities/_decorators.py
+++ b/src/chemcoord/_utilities/_decorators.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 #
 
 
-class Substitution(object):
+class Substitution:
     """
     A decorator to take a function's docstring and perform string
     substitution on it.
@@ -63,7 +63,7 @@ class Substitution(object):
         return result
 
 
-class Appender(object):
+class Appender:
     """
     A function decorator that will append an addendum to the docstring
     of the target function.

--- a/src/chemcoord/_utilities/typing.py
+++ b/src/chemcoord/_utilities/typing.py
@@ -10,9 +10,13 @@ i.e. the type is mostly useful to document intent to the developer.
 """
 
 import os
+from collections.abc import Sequence
 from typing import Any, Dict, Tuple, TypeAlias, TypeVar
 
 import numpy as np
+
+# Reexpose some pandas types
+from pandas._typing import Axes  # noqa: F401
 
 # We want the dtype to behave covariant, i.e. if a
 #  Vector[float] is allowed, then the more specific
@@ -48,3 +52,5 @@ Tensor = np.ndarray[Tuple[int, ...], np.dtype[T_dtype_co]]
 PathLike: TypeAlias = str | os.PathLike
 #: Type annotation for dictionaries holding keyword arguments.
 KwargDict: TypeAlias = Dict[str, Any]
+
+ArithmeticOther = float | np.floating | Sequence | Sequence[Sequence] | Vector | Matrix

--- a/src/chemcoord/_utilities/typing.py
+++ b/src/chemcoord/_utilities/typing.py
@@ -11,12 +11,13 @@ i.e. the type is mostly useful to document intent to the developer.
 
 import os
 from collections.abc import Sequence
-from typing import Any, Dict, Tuple, TypeAlias, TypeVar, Union
+from typing import Any, Dict, Tuple, TypeVar, Union
 
 import numpy as np
 
 # Reexpose some pandas types
 from pandas._typing import Axes  # noqa: F401
+from typing_extensions import TypeAlias
 
 # We want the dtype to behave covariant, i.e. if a
 #  Vector[float] is allowed, then the more specific

--- a/src/chemcoord/_utilities/typing.py
+++ b/src/chemcoord/_utilities/typing.py
@@ -1,0 +1,50 @@
+"""Define some types that do not fit into one particular module
+
+In particular it enables barebone typechecking for the shape of numpy arrays
+
+Inspired by
+https://stackoverflow.com/questions/75495212/type-hinting-numpy-arrays-and-batches
+
+Note that most numpy functions return :python:`ndarray[Any, Any]`
+i.e. the type is mostly useful to document intent to the developer.
+"""
+
+import os
+from typing import Any, Dict, Tuple, TypeAlias, TypeVar
+
+import numpy as np
+
+# We want the dtype to behave covariant, i.e. if a
+#  Vector[float] is allowed, then the more specific
+#  Vector[float64] should also be allowed.
+# Also see here:
+# https://stackoverflow.com/questions/61568462/what-does-typevara-b-covariant-true-mean
+#: Type annotation of a generic covariant type.
+T_dtype_co = TypeVar("T_dtype_co", bound=np.generic, covariant=True)
+
+# Currently we can define :code:`Matrix` and higher order tensors
+# only with shape :code`Tuple[int, ...]` because of
+# https://github.com/numpy/numpy/issues/27957
+# make the typechecks more strict over time, when shape checking finally comes to numpy.
+
+#: Type annotation of a vector.
+Vector = np.ndarray[Tuple[int], np.dtype[T_dtype_co]]
+#: Type annotation of a matrix.
+Matrix = np.ndarray[Tuple[int, ...], np.dtype[T_dtype_co]]
+#: Type annotation of a tensor.
+Tensor3D = np.ndarray[Tuple[int, ...], np.dtype[T_dtype_co]]
+#: Type annotation of a tensor.
+Tensor4D = np.ndarray[Tuple[int, ...], np.dtype[T_dtype_co]]
+#: Type annotation of a tensor.
+Tensor5D = np.ndarray[Tuple[int, ...], np.dtype[T_dtype_co]]
+#: Type annotation of a tensor.
+Tensor6D = np.ndarray[Tuple[int, ...], np.dtype[T_dtype_co]]
+#: Type annotation of a tensor.
+Tensor7D = np.ndarray[Tuple[int, ...], np.dtype[T_dtype_co]]
+#: Type annotation of a tensor.
+Tensor = np.ndarray[Tuple[int, ...], np.dtype[T_dtype_co]]
+
+#: Type annotation for pathlike objects.
+PathLike: TypeAlias = str | os.PathLike
+#: Type annotation for dictionaries holding keyword arguments.
+KwargDict: TypeAlias = Dict[str, Any]

--- a/src/chemcoord/_utilities/typing.py
+++ b/src/chemcoord/_utilities/typing.py
@@ -11,7 +11,7 @@ i.e. the type is mostly useful to document intent to the developer.
 
 import os
 from collections.abc import Sequence
-from typing import Any, Dict, Tuple, TypeAlias, TypeVar
+from typing import Any, Dict, Tuple, TypeAlias, TypeVar, Union
 
 import numpy as np
 
@@ -49,8 +49,10 @@ Tensor7D = np.ndarray[Tuple[int, ...], np.dtype[T_dtype_co]]
 Tensor = np.ndarray[Tuple[int, ...], np.dtype[T_dtype_co]]
 
 #: Type annotation for pathlike objects.
-PathLike: TypeAlias = str | os.PathLike
+PathLike: TypeAlias = Union[str, os.PathLike]
 #: Type annotation for dictionaries holding keyword arguments.
 KwargDict: TypeAlias = Dict[str, Any]
 
-ArithmeticOther = float | np.floating | Sequence | Sequence[Sequence] | Vector | Matrix
+ArithmeticOther = Union[
+    float, np.floating, Sequence, Sequence[Sequence], Vector, Matrix
+]

--- a/src/chemcoord/constants.py
+++ b/src/chemcoord/constants.py
@@ -15,7 +15,8 @@ from io import StringIO
 
 import numpy as np
 import pandas as pd
-from numba import njit
+
+from chemcoord._utilities._decorators import njit
 
 keys_below_are_abs_refs = -sys.maxsize + 100
 int_label = {
@@ -39,7 +40,7 @@ latex_repr = {
 }
 
 
-@njit(cache=True)
+@njit
 def _jit_absolute_refs(j):
     # Because dicts are not supported in numba :(
     if j == -sys.maxsize - 1:

--- a/tests/cartesian_coordinates/Cartesian/test_core.py
+++ b/tests/cartesian_coordinates/Cartesian/test_core.py
@@ -96,7 +96,7 @@ bond_dict = {
 
 
 def test_init():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         cc.Cartesian(5)
     with pytest.raises(PhysicalMeaning):
         cc.Cartesian(molecule.loc[:, ["atom", "x"]])


### PR DESCRIPTION
Part of #124 

- implemented the basic infrastructure for type-hints

- added a couple of type hints. 

- defined a custom `numba.njit` wrapper, that preserves the type information and sets `cache=True` by default. (related to and relevant for https://github.com/numba/numba/issues/7424)