### PR TITLE
do the getattr overload only at runtime

### DIFF
--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
@@ -3,7 +3,7 @@ import itertools
 from collections import Counter, defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence, Set
 from itertools import product
-from typing import Any, Literal, Union, cast, overload
+from typing import Any, Final, Literal, Union, cast, overload
 
 import numba as nb
 import numpy as np
@@ -37,6 +37,8 @@ from chemcoord.typing import (
     Vector,
 )
 
+COORDS: Final = ["x", "y", "z"]
+
 
 class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
     # Look into the numpy manual for description of __array_priority__:
@@ -53,7 +55,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         dtypes = [("atom", str), ("x", float), ("y", float), ("z", float)]
         frame = DataFrame(np.empty(len(atoms), dtype=dtypes), index=index)
         frame["atom"] = atoms
-        frame.loc[:, ["x", "y", "z"]] = coords
+        frame.loc[:, COORDS] = coords
         return cls(frame)
 
     def _return_appropiate_type(
@@ -88,115 +90,108 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             raise PhysicalMeaning(message)
 
     def __add__(self, other: Union[Self, ArithmeticOther]) -> Self:
-        coords = ["x", "y", "z"]
         new = self.copy()
         if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
-            new.loc[:, coords] = self.loc[:, coords] + other.loc[:, coords]
+            new.loc[:, COORDS] = self.loc[:, COORDS] + other.loc[:, COORDS]
         elif isinstance(other, DataFrame):
-            new.loc[:, coords] = self.loc[:, coords] + other.loc[:, coords]
+            new.loc[:, COORDS] = self.loc[:, COORDS] + other.loc[:, COORDS]
         else:
             try:
                 other = np.array(other, dtype="f8")
             except TypeError:
                 pass
-            new.loc[:, coords] = self.loc[:, coords] + other
+            new.loc[:, COORDS] = self.loc[:, COORDS] + other
         return new
 
     def __radd__(self, other: Union[Self, ArithmeticOther]) -> Self:
         return self.__add__(other)
 
     def __sub__(self, other: Union[Self, ArithmeticOther]) -> Self:
-        coords = ["x", "y", "z"]
         new = self.copy()
         if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
-            new.loc[:, coords] = self.loc[:, coords] - other.loc[:, coords]
+            new.loc[:, COORDS] = self.loc[:, COORDS] - other.loc[:, COORDS]
         elif isinstance(other, DataFrame):
-            new.loc[:, coords] = self.loc[:, coords] - other.loc[:, coords]
+            new.loc[:, COORDS] = self.loc[:, COORDS] - other.loc[:, COORDS]
         else:
             try:
                 other = np.array(other, dtype="f8")
             except TypeError:
                 pass
-            new.loc[:, coords] = self.loc[:, coords] - other
+            new.loc[:, COORDS] = self.loc[:, COORDS] - other
         return new
 
     def __rsub__(self, other: Union[Self, ArithmeticOther]) -> Self:
-        coords = ["x", "y", "z"]
         new = self.copy()
         if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
-            new.loc[:, coords] = other.loc[:, coords] - self.loc[:, coords]
+            new.loc[:, COORDS] = other.loc[:, COORDS] - self.loc[:, COORDS]
         elif isinstance(other, DataFrame):
-            new.loc[:, coords] = other.loc[:, coords] - self.loc[:, coords]
+            new.loc[:, COORDS] = other.loc[:, COORDS] - self.loc[:, COORDS]
         else:
             try:
                 other = np.array(other, dtype="f8")
             except TypeError:
                 pass
-            new.loc[:, coords] = other - self.loc[:, coords]
+            new.loc[:, COORDS] = other - self.loc[:, COORDS]
         return new
 
     def __mul__(self, other: Union[Self, ArithmeticOther]) -> Self:
-        coords = ["x", "y", "z"]
         new = self.copy()
         if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
-            new.loc[:, coords] = self.loc[:, coords] * other.loc[:, coords]
+            new.loc[:, COORDS] = self.loc[:, COORDS] * other.loc[:, COORDS]
         elif isinstance(other, DataFrame):
-            new.loc[:, coords] = self.loc[:, coords] * other.loc[:, coords]
+            new.loc[:, COORDS] = self.loc[:, COORDS] * other.loc[:, COORDS]
         else:
             try:
                 other = np.array(other, dtype="f8")
             except TypeError:
                 pass
-            new.loc[:, coords] = self.loc[:, coords] * other
+            new.loc[:, COORDS] = self.loc[:, COORDS] * other
         return new
 
     def __rmul__(self, other: Union[Self, ArithmeticOther]) -> Self:
         return self.__mul__(other)
 
     def __truediv__(self, other: Union[Self, ArithmeticOther]) -> Self:
-        coords = ["x", "y", "z"]
         new = self.copy()
         if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
-            new.loc[:, coords] = (
-                self.loc[:, coords].values / other.loc[:, coords].values
+            new.loc[:, COORDS] = (
+                self.loc[:, COORDS].values / other.loc[:, COORDS].values
             )
         elif isinstance(other, DataFrame):
-            new.loc[:, coords] = self.loc[:, coords] / other.loc[:, coords]
+            new.loc[:, COORDS] = self.loc[:, COORDS] / other.loc[:, COORDS]
         else:
             try:
                 other = np.array(other, dtype="f8")
             except TypeError:
                 pass
-            new.loc[:, coords] = self.loc[:, coords].values / other
+            new.loc[:, COORDS] = self.loc[:, COORDS].values / other
         return new
 
     def __rtruediv__(self, other: Union[Self, ArithmeticOther]) -> Self:
-        coords = ["x", "y", "z"]
         new = self.copy()
         if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
-            new.loc[:, coords] = (
-                other.loc[:, coords].values / self.loc[:, coords].values
+            new.loc[:, COORDS] = (
+                other.loc[:, COORDS].values / self.loc[:, COORDS].values
             )
         elif isinstance(other, DataFrame):
-            new.loc[:, coords] = other.loc[:, coords] / self.loc[:, coords]
+            new.loc[:, COORDS] = other.loc[:, COORDS] / self.loc[:, COORDS]
         else:
             try:
                 other = np.array(other, dtype="f8")
             except TypeError:
                 pass
-            new.loc[:, coords] = other / self.loc[:, coords].values
+            new.loc[:, COORDS] = other / self.loc[:, COORDS].values
         return new
 
     def __pow__(self, other: Union[Self, ArithmeticOther]) -> Self:
-        coords = ["x", "y", "z"]
         new = self.copy()
-        new.loc[:, coords] = self.loc[:, coords] ** other
+        new.loc[:, COORDS] = self.loc[:, COORDS] ** other
         return new
 
     def __pos__(self) -> Self:
@@ -206,9 +201,8 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         return -1 * self.copy()
 
     def __abs__(self) -> Self:
-        coords = ["x", "y", "z"]
         new = self.copy()
-        new.loc[:, coords] = abs(new.loc[:, coords])
+        new.loc[:, COORDS] = abs(new.loc[:, COORDS])
         return new
 
     def __matmul__(self, other: Matrix) -> Self:
@@ -218,9 +212,8 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
     #   Signatures of "__rmatmul__" of "CartesianCore" and "__matmul__" of
     #   "ndarray[tuple[int, ...], dtype[Any]]" are unsafely overlapping
     def __rmatmul__(self, other: Matrix) -> Self:  # type: ignore[misc]
-        coords = ["x", "y", "z"]
         new = self.copy()
-        new.loc[:, coords] = (np.dot(other, new.loc[:, coords].T)).T
+        new.loc[:, COORDS] = (np.dot(other, new.loc[:, COORDS].values.T)).T
         return new
 
     # Somehow the base class `object` expects the return type to be `bool``
@@ -260,7 +253,6 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             If all resulting sympy expressions in a column are numbers,
             the column is recasted to 64bit float.
         """
-        cols = ["x", "y", "z"]
         out = self.copy()
 
         def get_subs_f(*args: Any) -> Callable[[T], Union[T, float]]:
@@ -277,7 +269,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
 
             return subs_function
 
-        for col in cols:
+        for col in COORDS:
             if out.loc[:, col].dtype is np.dtype("O"):
                 out.loc[:, col] = out.loc[:, col].map(get_subs_f(*args))
                 try:
@@ -344,8 +336,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
     def _divide_et_impera(
         self, n_atoms_per_set: int = 500, offset: float = 3.0
     ) -> Tensor3D[set[AtomIdx]]:  # type: ignore[type-var]
-        coords = ["x", "y", "z"]
-        sorted_series = dict(zip(coords, [self[axis].sort_values() for axis in coords]))
+        sorted_series = dict(zip(COORDS, [self[axis].sort_values() for axis in COORDS]))
 
         def ceil(x: Real) -> int:
             return int(np.ceil(x))
@@ -373,7 +364,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
                 i: give_index(sorted_series[axis], i, n_atoms_per_set_along_axis)
                 for i in range(n_sets_along_axis)
             }
-            for axis in coords
+            for axis in COORDS
         }
 
         array_of_fragments = np.full([n_sets_along_axis] * 3, None, dtype="O")
@@ -450,7 +441,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             old_index = self.index
             self.index = range(len(self))  # type: ignore[assignment]
             fragments = self._divide_et_impera(offset=offset)
-            positions = np.array(self.loc[:, ["x", "y", "z"]], order="F")
+            positions = np.array(self.loc[:, COORDS], order="F")
             data = self.add_data([atomic_radius_data, "valency"])
             bond_radii = data[atomic_radius_data]
             if modified_properties is not None:
@@ -655,7 +646,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         if origin is None:
             return np.zeros(3)
         elif isinstance(origin, (int, np.integer)):
-            return cast(Vector[np.float64], self.loc[origin, ["x", "y", "z"]].values)
+            return cast(Vector[np.float64], self.loc[origin, COORDS].values)
         else:
             return np.asarray(origin, dtype="f8")
 
@@ -722,7 +713,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         c = a if c is None else c
 
         sides = np.array([a, b, c])
-        pos = self.loc[:, ["x", "y", "z"]]
+        pos = self.loc[:, COORDS].values
         if outside_sliced:
             molecule = self[((pos - origin) / (sides / 2)).max(axis=1) < 1.0]
         else:
@@ -741,7 +732,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         Returns:
             :class:`numpy.ndarray`:
         """
-        return np.mean(self.loc[:, ["x", "y", "z"]], axis=0)
+        return np.mean(self.loc[:, COORDS].values, axis=0)
 
     def get_barycenter(self) -> Vector[np.float64]:
         """Return the mass weighted average location.
@@ -756,7 +747,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             mass = self["mass"].values
         except KeyError:
             mass = self.add_data("mass")["mass"].values
-        pos = self.loc[:, ["x", "y", "z"]].values
+        pos = self.loc[:, COORDS].values
         return (pos * mass[:, None]).sum(axis=0) / self.get_total_mass()
 
     def get_bond_lengths(
@@ -783,16 +774,15 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         Returns:
             :class:`numpy.ndarray`: Vector of angles in degrees.
         """
-        coords = ["x", "y", "z"]
         if isinstance(indices, DataFrame):
-            i_pos = self.loc[indices.index, coords].values
-            b_pos = self.loc[indices.loc[:, "b"], coords].values
+            i_pos = self.loc[indices.index, COORDS].values
+            b_pos = self.loc[indices.loc[:, "b"], COORDS].values
         else:
             indices = np.array(indices)
             if len(indices.shape) == 1:
                 indices = indices[None, :]
-            i_pos = self.loc[indices[:, 0], coords].values
-            b_pos = self.loc[indices[:, 1], coords].values
+            i_pos = self.loc[indices[:, 0], COORDS].values
+            b_pos = self.loc[indices[:, 1], COORDS].values
         return np.linalg.norm(i_pos - b_pos, axis=1)
 
     def get_angle_degrees(
@@ -819,18 +809,17 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         Returns:
             :class:`numpy.ndarray`: Vector of angles in degrees.
         """
-        coords = ["x", "y", "z"]
         if isinstance(indices, DataFrame):
-            i_pos = self.loc[indices.index, coords].values
-            b_pos = self.loc[indices.loc[:, "b"], coords].values
-            a_pos = self.loc[indices.loc[:, "a"], coords].values
+            i_pos = self.loc[indices.index, COORDS].values
+            b_pos = self.loc[indices.loc[:, "b"], COORDS].values
+            a_pos = self.loc[indices.loc[:, "a"], COORDS].values
         else:
             indices = np.array(indices)
             if len(indices.shape) == 1:
                 indices = indices[None, :]
-            i_pos = self.loc[indices[:, 0], coords].values
-            b_pos = self.loc[indices[:, 1], coords].values
-            a_pos = self.loc[indices[:, 2], coords].values
+            i_pos = self.loc[indices[:, 0], COORDS].values
+            b_pos = self.loc[indices[:, 1], COORDS].values
+            a_pos = self.loc[indices[:, 2], COORDS].values
 
         BI, BA = i_pos - b_pos, a_pos - b_pos
         bi, ba = [v / np.linalg.norm(v, axis=1)[:, None] for v in (BI, BA)]
@@ -867,20 +856,19 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         Returns:
             :class:`numpy.ndarray`: Vector of angles in degrees.
         """
-        coords = ["x", "y", "z"]
         if isinstance(indices, DataFrame):
-            i_pos = self.loc[indices.index, coords].values
-            b_pos = self.loc[indices.loc[:, "b"], coords].values
-            a_pos = self.loc[indices.loc[:, "a"], coords].values
-            d_pos = self.loc[indices.loc[:, "d"], coords].values
+            i_pos = self.loc[indices.index, COORDS].values
+            b_pos = self.loc[indices.loc[:, "b"], COORDS].values
+            a_pos = self.loc[indices.loc[:, "a"], COORDS].values
+            d_pos = self.loc[indices.loc[:, "d"], COORDS].values
         else:
             indices = np.array(indices)
             if len(indices.shape) == 1:
                 indices = indices[None, :]
-            i_pos = self.loc[indices[:, 0], coords].values
-            b_pos = self.loc[indices[:, 1], coords].values
-            a_pos = self.loc[indices[:, 2], coords].values
-            d_pos = self.loc[indices[:, 3], coords].values
+            i_pos = self.loc[indices[:, 0], COORDS].values
+            b_pos = self.loc[indices[:, 1], COORDS].values
+            a_pos = self.loc[indices[:, 2], COORDS].values
+            d_pos = self.loc[indices[:, 3], COORDS].values
 
         IB = b_pos - i_pos
         BA = a_pos - b_pos
@@ -1114,9 +1102,8 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             ``d``:
             The distance between self and other. (float)
         """
-        coords = ["x", "y", "z"]
-        pos1 = self.loc[:, coords].values
-        pos2 = other.loc[:, coords].values
+        pos1 = self.loc[:, COORDS].values
+        pos2 = other.loc[:, COORDS].values
         D = self._jit_pairwise_distances(pos1, pos2)
         i, j = np.unravel_index(D.argmin(), D.shape)
         return AtomIdx(self.index[i]), AtomIdx(other.index[j]), float(D[i, j])  # type: ignore[call-overload]
@@ -1161,7 +1148,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
 
         def calculate_inertia_tensor(molecule: Self) -> tuple[Matrix, Matrix, Matrix]:
             masses = molecule.loc[:, "mass"].values
-            pos = molecule.loc[:, ["x", "y", "z"]].values
+            pos = molecule.loc[:, COORDS].values
             inertia = np.sum(
                 masses[:, None, None]
                 * (
@@ -1237,7 +1224,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         self.index = range(len(self))  # type: ignore[assignment]
         rename = {j: i for i, j in enumerate(old_index)}
 
-        pos = self.loc[:, ["x", "y", "z"]].values.astype("f8")
+        pos = self.loc[:, COORDS].values.astype("f8")
         out = np.empty((len(indices), 3))
         indices = np.array([rename.get(i, i) for i in indices], dtype="i8")
 
@@ -1265,10 +1252,10 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         new = self.loc[other_atoms, :].copy()
         norm = np.linalg.norm
         try:
-            new["distance"] = norm((new - origin).loc[:, ["x", "y", "z"]], axis=1)
+            new["distance"] = norm((new - origin).loc[:, COORDS].values, axis=1)
         except AttributeError:
             # Happens if molecule consists of only one atom
-            new["distance"] = norm((new - origin).loc[:, ["x", "y", "z"]])
+            new["distance"] = norm((new - origin).loc[:, COORDS].values)
         if sort:
             new.sort_values(by="distance", inplace=True)
         return new
@@ -1440,8 +1427,8 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             m1 = self
             m2 = other
 
-        pos1 = m1.loc[:, ["x", "y", "z"]].values
-        pos2 = m2.loc[m1.index, ["x", "y", "z"]].values
+        pos1 = m1.loc[:, COORDS].values
+        pos2 = m2.loc[m1.index, COORDS].values
         mass = m1.add_data("mass").loc[:, "mass"].values if mass_weight else None
 
         return xyz_functions.get_kabsch_rotation(pos1, pos2, mass)
@@ -1479,24 +1466,23 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             index_dct: dict[AtomIdx, AtomIdx],
         ) -> None:
             """Changes index_dct INPLACE"""
-            coords = ["x", "y", "z"]
             index1 = list(subset1)
             for m1_i in index1:
                 dist_m2_to_m1_i = m2.get_distance_to(
-                    cast(Vector[np.float64], m1.loc[m1_i, coords].values),
+                    cast(Vector[np.float64], m1.loc[m1_i, COORDS].values),
                     subset2,
                     sort=True,
                 )
 
                 m2_i = dist_m2_to_m1_i.index[0]
                 dist_new = dist_m2_to_m1_i.loc[m2_i, "distance"]
-                m2_pos_i = dist_m2_to_m1_i.loc[m2_i, coords]
+                m2_pos_i = dist_m2_to_m1_i.loc[m2_i, COORDS]
 
                 counter = itertools.count()
                 found = False
                 while not found:
                     if m2_i in index_dct.keys():
-                        old_m1_pos = m1.loc[index_dct[m2_i], coords]
+                        old_m1_pos = m1.loc[index_dct[m2_i], COORDS]
                         if dist_new < np.linalg.norm(m2_pos_i - old_m1_pos):
                             index1.append(index_dct[m2_i])
                             index_dct[m2_i] = m1_i
@@ -1504,7 +1490,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
                         else:
                             m2_i = dist_m2_to_m1_i.index[next(counter)]
                             dist_new = dist_m2_to_m1_i.loc[m2_i, "distance"]
-                            m2_pos_i = dist_m2_to_m1_i.loc[m2_i, coords]
+                            m2_pos_i = dist_m2_to_m1_i.loc[m2_i, COORDS]
                     else:
                         index_dct[m2_i] = m1_i
                         found = True

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
@@ -3,7 +3,7 @@ import itertools
 from collections import Counter, defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence, Set
 from itertools import product
-from typing import Any, Final, Literal, Union, cast, overload
+from typing import Any, Literal, Union, cast, overload
 
 import numba as nb
 import numpy as np
@@ -18,6 +18,7 @@ from typing_extensions import Self
 import chemcoord._cartesian_coordinates.xyz_functions as xyz_functions
 import chemcoord.constants as constants
 from chemcoord._cartesian_coordinates._cartesian_class_pandas_wrapper import (
+    COORDS,
     PandasWrapper,
 )
 from chemcoord._generic_classes.generic_core import GenericCore
@@ -36,8 +37,6 @@ from chemcoord.typing import (
     Tensor3D,
     Vector,
 )
-
-COORDS: Final = ["x", "y", "z"]
 
 
 class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_get_zmat.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_get_zmat.py
@@ -17,6 +17,9 @@ import chemcoord._cartesian_coordinates._cart_transformation as transformation
 import chemcoord._cartesian_coordinates.xyz_functions as xyz_functions
 import chemcoord.constants as constants
 from chemcoord._cartesian_coordinates._cartesian_class_core import CartesianCore
+from chemcoord._cartesian_coordinates._cartesian_class_pandas_wrapper import (
+    COORDS,
+)
 from chemcoord._internal_coordinates.zmat_class_main import Zmat
 from chemcoord._utilities._temporary_deprecation_workarounds import replace_without_warn
 from chemcoord.configuration import settings
@@ -450,7 +453,7 @@ class CartesianGetZmat(CartesianCore):
             raise ValueError(message(i=i))
         for k in range(3):
             if k < row:
-                A[k] = self.loc[c_table.iloc[row, k], ["x", "y", "z"]]  # type: ignore[index]
+                A[k] = self.loc[c_table.iloc[row, k], COORDS]  # type: ignore[index]
             else:
                 A[k] = abs_refs[c_table.iloc[row, k]]  # type: ignore[index]
         v1, v2 = A[2] - A[1], A[1] - A[0]
@@ -526,7 +529,7 @@ class CartesianGetZmat(CartesianCore):
         c_table.index = c_table.index.astype("i8")
 
         new_index = c_table.index.append(self.index.difference(c_table.index))
-        X = self.loc[new_index, ["x", "y", "z"]].values.astype("f8").T
+        X = self.loc[new_index, COORDS].values.astype("f8").T
         c_table = c_table.replace(dict(zip(new_index, range(len(self)))))
 
         err, C = transformation.get_C(X, c_table.values.T)
@@ -759,7 +762,7 @@ class CartesianGetZmat(CartesianCore):
             .replace({k: v for v, k in enumerate(c_table.index)})
             .values.T
         )
-        X = self.loc[:, ["x", "y", "z"]].values.T
+        X = self.loc[:, COORDS].values.T
         if X.dtype == np.dtype("i8"):
             X = X.astype("f8")
 

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
@@ -19,6 +19,9 @@ from typing_extensions import Self
 
 from chemcoord import constants
 from chemcoord._cartesian_coordinates._cartesian_class_core import CartesianCore
+from chemcoord._cartesian_coordinates._cartesian_class_pandas_wrapper import (
+    COORDS,
+)
 from chemcoord._generic_classes.generic_IO import GenericIO
 from chemcoord.configuration import settings
 from chemcoord.typing import (
@@ -427,7 +430,7 @@ class CartesianIO(CartesianCore, GenericIO):
         ]
 
         cjson_dict["atoms"]["coords"] = {}
-        coords = self.loc[:, ["x", "y", "z"]].values.reshape(len(self) * 3)
+        coords = self.loc[:, COORDS].values.reshape(len(self) * 3)
         cjson_dict["atoms"]["coords"]["3d"] = [float(x) for x in coords]
 
         bonds = []
@@ -569,7 +572,7 @@ class CartesianIO(CartesianCore, GenericIO):
         """
         return PyMatGenMolecule(
             self["atom"].values,
-            self.loc[:, ["x", "y", "z"]].values,  # type: ignore[arg-type]
+            self.loc[:, COORDS].values,  # type: ignore[arg-type]
         )
 
     @classmethod
@@ -601,7 +604,7 @@ class CartesianIO(CartesianCore, GenericIO):
             Returns:
                 :class:`ase.atoms.Atoms`:
             """
-            return AseAtoms("".join(self["atom"]), self.loc[:, ["x", "y", "z"]].values)
+            return AseAtoms("".join(self["atom"]), self.loc[:, COORDS].values)
 
         @classmethod
         def from_ase_atoms(cls, atoms: AseAtoms) -> Self:

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
@@ -601,7 +601,7 @@ class CartesianIO(CartesianCore, GenericIO):
             Returns:
                 :class:`ase.atoms.Atoms`:
             """
-            return AseAtoms("".join(self["atom"]), self.loc[:, ["x", "y", "z"]])
+            return AseAtoms("".join(self["atom"]), self.loc[:, ["x", "y", "z"]].values)
 
         @classmethod
         def from_ase_atoms(cls, atoms: AseAtoms) -> Self:

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_pandas_wrapper.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_pandas_wrapper.py
@@ -10,7 +10,7 @@ from typing_extensions import Self
 
 import chemcoord._cartesian_coordinates._indexers as indexers
 from chemcoord.exceptions import PhysicalMeaning
-from chemcoord.typing import SequenceNotStr
+from chemcoord.typing import Matrix, SequenceNotStr
 
 
 class PandasWrapper(indexers.Molecule):
@@ -158,6 +158,14 @@ class PandasWrapper(indexers.Molecule):
             if name in self._frame.columns:
                 return self[name]
             return object.__getattribute__(self, name)
+
+    @property
+    def values(self) -> Matrix:
+        """Returns the values.
+
+        Assigning a value to it changes the index.
+        """
+        return self._frame.values
 
     @property
     def index(self) -> Index:

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_pandas_wrapper.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_pandas_wrapper.py
@@ -1,6 +1,6 @@
 import copy
 from collections.abc import Sequence
-from typing import Any, Literal, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, Union, overload
 
 from pandas._typing import IndexLabel
 from pandas.core.frame import DataFrame
@@ -141,21 +141,23 @@ class PandasWrapper(indexers.Molecule):
         else:
             self._frame[key] = value
 
-    def __getattr__(self, name: str) -> Any:
-        """
-        After regular attribute access, try looking up the name
-        This allows simpler access to columns for interactive use.
-        """
-        # Note: obj.x will always call obj.__getattribute__('x') prior to
-        # calling obj.__getattr__('x').
+    if not TYPE_CHECKING:
 
-        if name.startswith("__"):
-            # See here, why we do this
-            # https://stackoverflow.com/questions/47299243/recursionerror-when-python-copy-deepcopy
-            raise AttributeError()
-        if name in self._frame.columns:
-            return self[name]
-        return object.__getattribute__(self, name)
+        def __getattr__(self, name: str) -> Any:
+            """
+            After regular attribute access, try looking up the name
+            This allows simpler access to columns for interactive use.
+            """
+            # Note: obj.x will always call obj.__getattribute__('x') prior to
+            # calling obj.__getattr__('x').
+
+            if name.startswith("__"):
+                # See here, why we do this
+                # https://stackoverflow.com/questions/47299243/recursionerror-when-python-copy-deepcopy
+                raise AttributeError()
+            if name in self._frame.columns:
+                return self[name]
+            return object.__getattribute__(self, name)
 
     @property
     def index(self) -> Index:

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_pandas_wrapper.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_pandas_wrapper.py
@@ -159,6 +159,24 @@ class PandasWrapper(indexers.Molecule):
                 return self[name]
             return object.__getattribute__(self, name)
 
+    # manually implement the attribute access for the columns
+    # atom, x, y, z statically
+    @property
+    def atom(self) -> Series:
+        return self.loc[:, "atom"]
+
+    @property
+    def x(self) -> Series:
+        return self.loc[:, "x"]
+
+    @property
+    def y(self) -> Series:
+        return self.loc[:, "y"]
+
+    @property
+    def z(self) -> Series:
+        return self.loc[:, "z"]
+
     @property
     def values(self) -> Matrix:
         """Returns the values.
@@ -202,22 +220,6 @@ class PandasWrapper(indexers.Molecule):
     @property
     def dtypes(self) -> Series:
         return self._frame.dtypes
-
-    @property
-    def atom(self) -> Series:
-        return self.loc[:, "atom"]
-
-    @property
-    def x(self) -> Series:
-        return self.loc[:, "x"]
-
-    @property
-    def y(self) -> Series:
-        return self.loc[:, "y"]
-
-    @property
-    def z(self) -> Series:
-        return self.loc[:, "z"]
 
     @overload
     def sort_values(

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_pandas_wrapper.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_pandas_wrapper.py
@@ -1,6 +1,6 @@
 import copy
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Literal, Union, overload
+from typing import TYPE_CHECKING, Any, Final, Literal, Union, overload
 
 from pandas._typing import IndexLabel
 from pandas.core.frame import DataFrame
@@ -11,6 +11,8 @@ from typing_extensions import Self
 import chemcoord._cartesian_coordinates._indexers as indexers
 from chemcoord.exceptions import PhysicalMeaning
 from chemcoord.typing import Matrix, SequenceNotStr
+
+COORDS: Final = ["x", "y", "z"]
 
 
 class PandasWrapper(indexers.Molecule):

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_pandas_wrapper.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_pandas_wrapper.py
@@ -203,6 +203,22 @@ class PandasWrapper(indexers.Molecule):
     def dtypes(self) -> Series:
         return self._frame.dtypes
 
+    @property
+    def atom(self) -> Series:
+        return self.loc[:, "atom"]
+
+    @property
+    def x(self) -> Series:
+        return self.loc[:, "x"]
+
+    @property
+    def y(self) -> Series:
+        return self.loc[:, "y"]
+
+    @property
+    def z(self) -> Series:
+        return self.loc[:, "z"]
+
     @overload
     def sort_values(
         self,

--- a/src/chemcoord/_cartesian_coordinates/asymmetric_unit_cartesian_class.py
+++ b/src/chemcoord/_cartesian_coordinates/asymmetric_unit_cartesian_class.py
@@ -1,5 +1,6 @@
 import pandas as pd
 
+from chemcoord._cartesian_coordinates._cartesian_class_pandas_wrapper import COORDS
 from chemcoord._cartesian_coordinates.cartesian_class_main import Cartesian
 
 
@@ -21,7 +22,6 @@ class AsymmetricUnitCartesian(Cartesian):
         Returns:
             Cartesian: A new cartesian instance.
         """
-        coords = ["x", "y", "z"]
         eq_sets = self._metadata["eq"]["eq_sets"]
         sym_ops = self._metadata["eq"]["sym_ops"]
         frame = pd.DataFrame(
@@ -32,8 +32,8 @@ class AsymmetricUnitCartesian(Cartesian):
         frame["atom"] = pd.Series(
             {i: self.loc[k, "atom"] for k, v in eq_sets.items() for i in v}
         )
-        frame.loc[self.index, coords] = self.loc[:, coords].values
+        frame.loc[self.index, COORDS] = self.loc[:, COORDS].values
         for i in eq_sets:
             for j in eq_sets[i]:
-                frame.loc[j, coords] = sym_ops[i][j] @ frame.loc[i, coords]
+                frame.loc[j, COORDS] = sym_ops[i][j] @ frame.loc[i, COORDS]
         return Cartesian(frame)

--- a/src/chemcoord/_cartesian_coordinates/xyz_functions.py
+++ b/src/chemcoord/_cartesian_coordinates/xyz_functions.py
@@ -16,6 +16,7 @@ from chemcoord._cartesian_coordinates._cart_transformation import (
     _jit_normalize,
     normalize,
 )
+from chemcoord._cartesian_coordinates._cartesian_class_core import COORDS
 from chemcoord._cartesian_coordinates.cartesian_class_main import Cartesian
 from chemcoord._internal_coordinates.zmat_class_main import Zmat
 from chemcoord._utilities._decorators import njit
@@ -253,7 +254,6 @@ def isclose(
     Returns:
         :class:`numpy.ndarray`: Boolean array.
     """
-    coords = ["x", "y", "z"]
     # The pandas documentation says about the arguments to all(axis=...)
     #   None : reduce all axes, return a scalar
     # https://pandas.pydata.org/docs/reference/api/pandas.Series.all.html
@@ -268,11 +268,11 @@ def isclose(
     if align:
         a = a.get_inertia()["transformed_Cartesian"]
         b = b.get_inertia()["transformed_Cartesian"]
-    A, B = a.loc[:, coords], b.loc[a.index, coords]
+    A, B = a.loc[:, COORDS].values, b.loc[a.index, COORDS].values
 
-    out = pd.DataFrame(index=a.index, columns=["atom"] + coords, dtype=bool)
+    out = pd.DataFrame(index=a.index, columns=["atom"] + COORDS, dtype=bool)
     out.loc[:, "atom"] = True
-    out.loc[:, coords] = np.isclose(A, B, rtol=rtol, atol=atol)
+    out.loc[:, COORDS] = np.isclose(A, B, rtol=rtol, atol=atol)
     return out
 
 
@@ -486,7 +486,7 @@ def apply_grad_zmat_tensor(
         np.empty(len(construction_table), dtype=dtypes), index=cart_dist.index
     )
 
-    X_dist = cart_dist.loc[:, ["x", "y", "z"]].values.T
+    X_dist = cart_dist.loc[:, COORDS].values.T
     C_dist = np.tensordot(grad_C, X_dist, axes=([3, 2], [0, 1])).T
     if C_dist.dtype == np.dtype("i8"):
         C_dist = C_dist.astype("f8")

--- a/src/chemcoord/_internal_coordinates/_zmat_class_core.py
+++ b/src/chemcoord/_internal_coordinates/_zmat_class_core.py
@@ -120,6 +120,36 @@ class ZmatCore(PandasWrapper, GenericCore):  # noqa: PLW1641
                 return self[name]
             return object.__getattribute__(self, name)
 
+    # manually implement the attribute access for the columns
+    # atom, b, a, d, bond, angle, dihedral statically
+    @property
+    def atom(self) -> Series:
+        return self.loc[:, "atom"]
+
+    @property
+    def b(self) -> Series:
+        return self.loc[:, "b"]
+
+    @property
+    def a(self) -> Series:
+        return self.loc[:, "a"]
+
+    @property
+    def d(self) -> Series:
+        return self.loc[:, "d"]
+
+    @property
+    def bond(self) -> Series:
+        return self.loc[:, "bond"]
+
+    @property
+    def angle(self) -> Series:
+        return self.loc[:, "angle"]
+
+    @property
+    def dihedral(self) -> Series:
+        return self.loc[:, "dihedral"]
+
     @property
     @append_indexer_docstring
     def loc(self) -> indexers._Loc:

--- a/src/chemcoord/_internal_coordinates/_zmat_class_core.py
+++ b/src/chemcoord/_internal_coordinates/_zmat_class_core.py
@@ -4,7 +4,7 @@ import copy
 import warnings
 from collections.abc import Sequence
 from functools import partial
-from typing import TYPE_CHECKING, Callable, Literal, Union, overload
+from typing import TYPE_CHECKING, Any, Callable, Literal, Union, overload
 
 import numpy as np
 import pandas as pd
@@ -102,21 +102,23 @@ class ZmatCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             selected = self._frame[key]
         return selected
 
-    def __getattr__(self, name: str):
-        """
-        After regular attribute access, try looking up the name
-        This allows simpler access to columns for interactive use.
-        """
-        # Note: obj.x will always call obj.__getattribute__('x') prior to
-        # calling obj.__getattr__('x').
+    if not TYPE_CHECKING:
 
-        if name.startswith("__"):
-            # See here, why we do this
-            # https://stackoverflow.com/questions/47299243/recursionerror-when-python-copy-deepcopy
-            raise AttributeError()
-        if name in self._frame.columns:
-            return self[name]
-        return object.__getattribute__(self, name)
+        def __getattr__(self, name: str) -> Any:
+            """
+            After regular attribute access, try looking up the name
+            This allows simpler access to columns for interactive use.
+            """
+            # Note: obj.x will always call obj.__getattribute__('x') prior to
+            # calling obj.__getattr__('x').
+
+            if name.startswith("__"):
+                # See here, why we do this
+                # https://stackoverflow.com/questions/47299243/recursionerror-when-python-copy-deepcopy
+                raise AttributeError()
+            if name in self._frame.columns:
+                return self[name]
+            return object.__getattribute__(self, name)
 
     @property
     @append_indexer_docstring

--- a/tests/cartesian_coordinates/Cartesian/test_core.py
+++ b/tests/cartesian_coordinates/Cartesian/test_core.py
@@ -248,9 +248,7 @@ def test_get_bonds():
     }
     assert (
         molecule.get_bonds(
-            modified_properties={
-                k: 0.0 for k in molecule[molecule["atom"] == "C"].index
-            }
+            modified_properties={k: 0.0 for k in molecule[molecule.atom == "C"].index}
         )
         == modified_expected
     )


### PR DESCRIPTION
do the getattr overload only at runtime
Otherwise non-existent attributes cannot be flagged by mypy.

The attribute access is a convenience for the user, not something for the developer, because it hides to many bugs.

Attribute access to columns
`atom, x, y, z` for Cartesians and
`atom, b, a, d, bond, angle, dihedral` for Zmatrices is still possible.

Added a variable `COORDS: Final = ['x', 'y', 'z']` instead of retyping it all the time.

(added a `.values` `@property` getter similar to the one of a DataFrame)