### PR TITLE
follow untyped imports

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,7 @@
     no_implicit_optional = True
     disallow_untyped_defs = True
     check_untyped_defs = True
+    follow_untyped_imports = True
 
 
 # explicitly blacklist files, this means we can easily add in stricter type checks

--- a/src/chemcoord/_cartesian_coordinates/_cart_transformation.py
+++ b/src/chemcoord/_cartesian_coordinates/_cart_transformation.py
@@ -1,5 +1,6 @@
 import numba as nb
 import numpy as np
+from numba.core.types import f8
 from numba.extending import overload
 from numpy import arccos, arctan2, sqrt
 
@@ -1097,7 +1098,7 @@ def get_grad_B(X, c_table, j):
     return grad_B
 
 
-@njit(nb.f8[:](nb.f8[:]))
+@njit(f8[:](f8[:]))
 def get_S_inv(v):
     x, y, z = v
     r = np.linalg.norm(v)
@@ -1108,7 +1109,7 @@ def get_S_inv(v):
     return np.array([r, alpha, delta])
 
 
-@njit(nb.f8[:, :](nb.f8[:]))
+@njit(f8[:, :](f8[:]))
 def get_grad_S_inv(v):
     x, y, z = v
     grad_S_inv = np.zeros((3, 3))

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
@@ -5,7 +5,6 @@ from collections.abc import Callable, Iterable, Mapping, Sequence, Set
 from itertools import product
 from typing import Any, Literal, Union, cast, overload
 
-import numba as nb
 import numpy as np
 import pandas as pd
 from ordered_set import OrderedSet
@@ -283,12 +282,12 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         pos: Matrix[np.floating],
         bond_radii: Vector[np.floating],
         self_bonding_allowed: bool = False,
-    ) -> Matrix[np.float64]:
+    ) -> Matrix[np.bool_]:
         """Calculate a boolean array where ``A[i,j] is True`` indicates a
         bond between the i-th and j-th atom.
         """
         n = pos.shape[0]
-        bond_array = np.empty((n, n), dtype=nb.boolean)
+        bond_array = np.empty((n, n), dtype=np.bool_)
 
         for i in range(n):
             for j in range(i, n):
@@ -478,7 +477,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         return bond_dict
 
     def _give_val_sorted_bond_dict(self, use_lookup: bool) -> dict[AtomIdx, SortedSet]:
-        def complete_calculation() -> dict[AtomIdx, SortedSet[AtomIdx]]:
+        def complete_calculation() -> dict[AtomIdx, SortedSet]:
             bond_dict = self.get_bonds(use_lookup=use_lookup)
             valency = dict(zip(self.index, self.add_data("valency")["valency"]))
             val_bond_dict = {


### PR DESCRIPTION
we now follow untyped imports.

Before this change anything from an untyped module was replaced by Any.