### PR TITLE
Increment min version use modern union

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ run_tests: &run_tests
 workflows:
   sample:
     jobs:
-      - py39
       - py310
       - py310_analysis
       - py311
@@ -54,11 +53,6 @@ workflows:
       - py312
 
 jobs:
-  py39:
-    <<: *run_tests
-    docker:
-      - image: cimg/python:3.9
-
   py310:
     <<: *run_tests
     docker:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ CLASSIFIERS = [
     "Operating System :: Microsoft :: Windows",
     "Natural Language :: English",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -76,7 +75,7 @@ def setup_package():
         packages=find_packages("src"),
         package_dir={"": "src"},
         install_requires=INSTALL_REQUIRES,
-        python_requires=">=3.8",
+        python_requires=">=3.10",
     )
 
 

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
@@ -3,7 +3,7 @@ import itertools
 from collections import Counter, defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence, Set
 from itertools import product
-from typing import Any, Literal, Union, cast, overload
+from typing import Any, Literal, cast, overload
 
 import numpy as np
 import pandas as pd
@@ -48,7 +48,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         cls,
         atoms: Sequence[str],
         coords: Matrix,
-        index: Union[Axes, None] = None,
+        index: Axes | None = None,
     ) -> Self:
         dtypes = [("atom", str), ("x", float), ("y", float), ("z", float)]
         frame = DataFrame(np.empty(len(atoms), dtype=dtypes), index=index)
@@ -57,8 +57,8 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         return cls(frame)
 
     def _return_appropiate_type(
-        self, selected: Union[Series, DataFrame]
-    ) -> Union[Self, Series, DataFrame]:
+        self, selected: Series | DataFrame
+    ) -> Self | Series | DataFrame:
         if isinstance(selected, Series):
             frame = DataFrame(selected).T
             if self._required_cols <= set(frame.columns):
@@ -87,7 +87,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             )
             raise PhysicalMeaning(message)
 
-    def __add__(self, other: Union[Self, ArithmeticOther]) -> Self:
+    def __add__(self, other: Self | ArithmeticOther) -> Self:
         new = self.copy()
         if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
@@ -102,10 +102,10 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             new.loc[:, COORDS] = self.loc[:, COORDS] + other
         return new
 
-    def __radd__(self, other: Union[Self, ArithmeticOther]) -> Self:
+    def __radd__(self, other: Self | ArithmeticOther) -> Self:
         return self.__add__(other)
 
-    def __sub__(self, other: Union[Self, ArithmeticOther]) -> Self:
+    def __sub__(self, other: Self | ArithmeticOther) -> Self:
         new = self.copy()
         if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
@@ -120,7 +120,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             new.loc[:, COORDS] = self.loc[:, COORDS] - other
         return new
 
-    def __rsub__(self, other: Union[Self, ArithmeticOther]) -> Self:
+    def __rsub__(self, other: Self | ArithmeticOther) -> Self:
         new = self.copy()
         if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
@@ -135,7 +135,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             new.loc[:, COORDS] = other - self.loc[:, COORDS]
         return new
 
-    def __mul__(self, other: Union[Self, ArithmeticOther]) -> Self:
+    def __mul__(self, other: Self | ArithmeticOther) -> Self:
         new = self.copy()
         if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
@@ -150,10 +150,10 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             new.loc[:, COORDS] = self.loc[:, COORDS] * other
         return new
 
-    def __rmul__(self, other: Union[Self, ArithmeticOther]) -> Self:
+    def __rmul__(self, other: Self | ArithmeticOther) -> Self:
         return self.__mul__(other)
 
-    def __truediv__(self, other: Union[Self, ArithmeticOther]) -> Self:
+    def __truediv__(self, other: Self | ArithmeticOther) -> Self:
         new = self.copy()
         if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
@@ -170,7 +170,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             new.loc[:, COORDS] = self.loc[:, COORDS].values / other
         return new
 
-    def __rtruediv__(self, other: Union[Self, ArithmeticOther]) -> Self:
+    def __rtruediv__(self, other: Self | ArithmeticOther) -> Self:
         new = self.copy()
         if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
@@ -187,7 +187,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             new.loc[:, COORDS] = other / self.loc[:, COORDS].values
         return new
 
-    def __pow__(self, other: Union[Self, ArithmeticOther]) -> Self:
+    def __pow__(self, other: Self | ArithmeticOther) -> Self:
         new = self.copy()
         new.loc[:, COORDS] = self.loc[:, COORDS] ** other
         return new
@@ -253,8 +253,8 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         """
         out = self.copy()
 
-        def get_subs_f(*args: Any) -> Callable[[T], Union[T, float]]:
-            def subs_function(x: T) -> Union[T, float]:
+        def get_subs_f(*args: Any) -> Callable[[T], T | float]:
+            def subs_function(x: T) -> T | float:
                 if hasattr(x, "subs"):
                     x = x.subs(*args)
                     try:
@@ -309,7 +309,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         bond_radii: Vector[np.floating],
         bond_dict: defaultdict[AtomIdx, set[AtomIdx]],
         self_bonding_allowed: bool = False,
-        convert_index: Union[Mapping[AtomIdx, AtomIdx], None] = None,
+        convert_index: Mapping[AtomIdx, AtomIdx] | None = None,
     ) -> None:
         """If bond_dict is provided, this function is not side effect free
         bond_dict has to be a defaultdict(set)
@@ -327,7 +327,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         bond_array = self._jit_give_bond_array(
             frag_pos, frag_bond_radii, self_bonding_allowed=self_bonding_allowed
         )
-        a, b = [[convert_index[i] for i in a] for a in bond_array.nonzero()]
+        a, b = ([convert_index[i] for i in a] for a in bond_array.nonzero())
         for row, index in enumerate(a):
             bond_dict[index].add(b[row])
 
@@ -379,10 +379,10 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         self,
         self_bonding_allowed: bool = False,
         offset: float = 3.0,
-        modified_properties: Union[Mapping[AtomIdx, float], None] = None,
+        modified_properties: Mapping[AtomIdx, float] | None = None,
         use_lookup: bool = False,
         set_lookup: bool = True,
-        atomic_radius_data: Union[str, None] = None,
+        atomic_radius_data: str | None = None,
     ) -> dict[AtomIdx, set[AtomIdx]]:
         """Return a dictionary representing the bonds.
 
@@ -504,8 +504,8 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         n_sphere: float = ...,
         give_only_index: Literal[False] = False,
         only_surface: bool = ...,
-        exclude: Union[set[AtomIdx], None] = ...,
-        use_lookup: Union[bool, None] = ...,
+        exclude: set[AtomIdx] | None = ...,
+        use_lookup: bool | None = ...,
     ) -> Self: ...
 
     @overload
@@ -516,8 +516,8 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         n_sphere: float = ...,
         give_only_index: Literal[True],
         only_surface: bool = ...,
-        exclude: Union[set[AtomIdx], None] = ...,
-        use_lookup: Union[bool, None] = ...,
+        exclude: set[AtomIdx] | None = ...,
+        use_lookup: bool | None = ...,
     ) -> set[AtomIdx]: ...
 
     def get_coordination_sphere(
@@ -527,9 +527,9 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         n_sphere: float = 1,
         give_only_index: bool = False,
         only_surface: bool = True,
-        exclude: Union[set[AtomIdx], None] = None,
-        use_lookup: Union[bool, None] = None,
-    ) -> Union[Self, set[AtomIdx]]:
+        exclude: set[AtomIdx] | None = None,
+        use_lookup: bool | None = None,
+    ) -> Self | set[AtomIdx]:
         """Return a Cartesian of atoms in the n-th coordination sphere.
 
         Connected means that a path along covalent bonds exists.
@@ -563,7 +563,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
                 f"{n_sphere}."
             )
         if n_sphere > 0:
-            visited = set([i]) | exclude
+            visited = {i} | exclude
             try:
                 tmp_bond_dict = {j: (bond_dict[j] - visited) for j in bond_dict[i]}
             except KeyError:
@@ -592,7 +592,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             return self.loc[index_out - exclude]
 
     def _preserve_bonds(
-        self, sliced_cartesian: Self, use_lookup: Union[bool, None] = None
+        self, sliced_cartesian: Self, use_lookup: bool | None = None
     ) -> Self:
         """Is called after cutting geometric shapes.
 
@@ -620,11 +620,11 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             "The sliced Cartesian has to be a subset of the bigger frame"
         )
         bond_dic = self.get_bonds(use_lookup=use_lookup)
-        new_atoms: set[AtomIdx] = set([])
+        new_atoms: set[AtomIdx] = set()
         for atom in included_atoms_set:
             new_atoms = new_atoms | bond_dic[atom]
         new_atoms = new_atoms - included_atoms_set
-        while not new_atoms == set([]):
+        while not new_atoms == set():
             index_of_interest = new_atoms.pop()
             included_atoms_set = included_atoms_set | self.get_coordination_sphere(
                 index_of_interest,
@@ -639,7 +639,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         return molecule
 
     def _get_origin(
-        self, origin: Union[Vector[np.floating], Series, int, Sequence[Real], None]
+        self, origin: Vector[np.floating] | Series | int | Sequence[Real] | None
     ) -> Vector[np.float64]:
         if origin is None:
             return np.zeros(3)
@@ -651,7 +651,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
     def cut_sphere(
         self,
         radius: Real = 15.0,
-        origin: Union[Vector[np.floating], AtomIdx, Sequence[Real], None] = None,
+        origin: Vector[np.floating] | AtomIdx | Sequence[Real] | None = None,
         outside_sliced: bool = True,
         preserve_bonds: bool = False,
     ) -> Self:
@@ -684,9 +684,9 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
     def cut_cuboid(
         self,
         a: float = 20.0,
-        b: Union[float, None] = None,
-        c: Union[float, None] = None,
-        origin: Union[AtomIdx, Vector[np.floating], Sequence[Real], None] = None,
+        b: float | None = None,
+        c: float | None = None,
+        origin: AtomIdx | Vector[np.floating] | Sequence[Real] | None = None,
         outside_sliced: bool = True,
         preserve_bonds: bool = False,
     ) -> Self:
@@ -750,11 +750,11 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
 
     def get_bond_lengths(
         self,
-        indices: Union[
-            Matrix,
-            Sequence[Union[tuple[Integral, Integral], Sequence[Integral]]],
-            DataFrame,
-        ],
+        indices: (
+            Matrix
+            | Sequence[tuple[Integral, Integral] | Sequence[Integral]]
+            | DataFrame
+        ),
     ) -> Vector[np.float64]:
         """Return the distances between given atoms.
 
@@ -785,11 +785,11 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
 
     def get_angle_degrees(
         self,
-        indices: Union[
-            Matrix,
-            Sequence[Union[tuple[Integral, Integral, Integral], Sequence[Integral]]],
-            DataFrame,
-        ],
+        indices: (
+            Matrix
+            | Sequence[tuple[Integral, Integral, Integral] | Sequence[Integral]]
+            | DataFrame
+        ),
     ) -> Vector[np.float64]:
         """Return the angles between given atoms.
 
@@ -820,7 +820,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             a_pos = self.loc[indices[:, 2], COORDS].values
 
         BI, BA = i_pos - b_pos, a_pos - b_pos
-        bi, ba = [v / np.linalg.norm(v, axis=1)[:, None] for v in (BI, BA)]
+        bi, ba = (v / np.linalg.norm(v, axis=1)[:, None] for v in (BI, BA))
         dot_product = np.sum(bi * ba, axis=1)
         dot_product[dot_product > 1] = 1
         dot_product[dot_product < -1] = -1
@@ -828,13 +828,11 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
 
     def get_dihedral_degrees(
         self,
-        indices: Union[
-            Matrix[np.integer],
-            Sequence[
-                Union[tuple[AtomIdx, AtomIdx, AtomIdx, AtomIdx], Sequence[AtomIdx]]
-            ],
-            DataFrame,
-        ],
+        indices: (
+            Matrix[np.integer]
+            | Sequence[tuple[AtomIdx, AtomIdx, AtomIdx, AtomIdx] | Sequence[AtomIdx]]
+            | DataFrame
+        ),
         start_row: int = 0,
     ) -> Vector[np.float64]:
         """Return the dihedrals between given atoms.
@@ -874,7 +872,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
 
         N1 = np.cross(IB, BA, axis=1)
         N2 = np.cross(BA, AD, axis=1)
-        n1, n2 = [v / np.linalg.norm(v, axis=1)[:, None] for v in (N1, N2)]
+        n1, n2 = (v / np.linalg.norm(v, axis=1)[:, None] for v in (N1, N2))
 
         dot_product = np.sum(n1 * n2, axis=1)
         dot_product[dot_product > 1] = 1
@@ -898,17 +896,17 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
     def fragmentate(
         self,
         give_only_index: Literal[False] = False,
-        use_lookup: Union[bool, None] = ...,
+        use_lookup: bool | None = ...,
     ) -> list[Self]: ...
 
     @overload
     def fragmentate(
-        self, give_only_index: Literal[True], use_lookup: Union[bool, None] = ...
+        self, give_only_index: Literal[True], use_lookup: bool | None = ...
     ) -> list[set[AtomIdx]]: ...
 
     def fragmentate(
-        self, give_only_index: bool = False, use_lookup: Union[bool, None] = None
-    ) -> Union[list[Self], list[set[AtomIdx]]]:
+        self, give_only_index: bool = False, use_lookup: bool | None = None
+    ) -> list[Self] | list[set[AtomIdx]]:
         """Get the indices of non bonded parts in the molecule.
 
         Args:
@@ -926,7 +924,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         if use_lookup is None:
             use_lookup = settings["defaults"]["use_lookup"]
 
-        fragments: Union[list[set[AtomIdx]], list[Self]] = []
+        fragments: list[set[AtomIdx]] | list[Self] = []
         pending = set(self.index)
         self.get_bonds(use_lookup=use_lookup)
 
@@ -974,7 +972,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         self,
         list_of_indextuples: Sequence[tuple[AtomIdx, AtomIdx]],
         give_only_index: Literal[False] = False,
-        use_lookup: Union[bool, None] = None,
+        use_lookup: bool | None = None,
     ) -> Self: ...
 
     @overload
@@ -982,15 +980,15 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         self,
         list_of_indextuples: Sequence[tuple[AtomIdx, AtomIdx]],
         give_only_index: Literal[True],
-        use_lookup: Union[bool, None] = None,
+        use_lookup: bool | None = None,
     ) -> set[AtomIdx]: ...
 
     def get_fragment(
         self,
         list_of_indextuples: Sequence[tuple[AtomIdx, AtomIdx]],
         give_only_index: bool = False,
-        use_lookup: Union[bool, None] = None,
-    ) -> Union[Self, set[AtomIdx]]:
+        use_lookup: bool | None = None,
+    ) -> Self | set[AtomIdx]:
         """Get the indices of the atoms in a fragment.
 
         The list_of_indextuples contains all bondings from the
@@ -1033,8 +1031,8 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
 
     def get_without(
         self,
-        fragments: Union[Self, Sequence[Self]],
-        use_lookup: Union[bool, None] = None,
+        fragments: Self | Sequence[Self],
+        use_lookup: bool | None = None,
     ) -> list[Self]:
         """Return self without the specified fragments.
 
@@ -1176,7 +1174,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
     def basistransform(
         self,
         new_basis: Matrix,
-        old_basis: Union[Matrix, None] = None,
+        old_basis: Matrix | None = None,
         orthonormalize: bool = True,
     ) -> Self:
         """Transform the frame to a new basis.
@@ -1216,7 +1214,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             return cast(Self, np.linalg.inv(new_basis) @ old_basis @ self)
 
     def _get_positions(
-        self, indices: Union[Vector[np.integer], Sequence[int]]
+        self, indices: Vector[np.integer] | Sequence[int]
     ) -> Matrix[np.float64]:
         old_index = self.index
         self.index = range(len(self))  # type: ignore[assignment]
@@ -1237,8 +1235,8 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
 
     def get_distance_to(
         self,
-        origin: Union[Vector[np.floating], AtomIdx, Sequence[Real], None] = None,
-        other_atoms: Union[Index, SequenceNotStr[int], Set[int], None] = None,
+        origin: Vector[np.floating] | AtomIdx | Sequence[Real] | None = None,
+        other_atoms: Index | SequenceNotStr[int] | Set[int] | None = None,
         sort: bool = False,
     ) -> Self:
         """Return a Cartesian with a column for the distance from origin."""
@@ -1274,7 +1272,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
 
     def change_numbering(
         self, rename_dict: dict[AtomIdx, AtomIdx], inplace: bool = False
-    ) -> Union[Self, None]:
+    ) -> Self | None:
         """Return the reindexed version of Cartesian.
 
         Args:
@@ -1292,7 +1290,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             return None
 
     def partition_chem_env(
-        self, n_sphere: int = 4, use_lookup: Union[bool, None] = None
+        self, n_sphere: int = 4, use_lookup: bool | None = None
     ) -> dict[tuple[str, frozenset[tuple[str, int]]], set[AtomIdx]]:
         """This function partitions the molecule into subsets of the
         same chemical environment.

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
@@ -9,7 +9,7 @@ from collections.abc import Hashable
 from functools import partial
 from threading import Thread
 from types import ModuleType
-from typing import Any, Literal, Union, overload
+from typing import Any, Literal, overload
 
 import numpy as np
 import pandas as pd
@@ -33,13 +33,13 @@ from chemcoord.typing import (
     WriteBuffer,
 )
 
-pyscf: Union[ModuleType, None] = None
+pyscf: ModuleType | None = None
 try:
     import pyscf  # type: ignore[no-redef]
     from pyscf.gto.mole import Mole
 except ImportError:
     pass
-ase: Union[ModuleType, None] = None
+ase: ModuleType | None = None
 try:
     import ase  # type: ignore[no-redef]
     from ase.atoms import Atoms as AseAtoms
@@ -72,67 +72,67 @@ class CartesianIO(CartesianCore, GenericIO):
             return (insert_txt + substr).join(txt.split(substr))
 
         html_txt = new._frame._repr_html_()  # type: ignore[operator]
-        insert_txt = "<caption>{}</caption>\n".format(self.__class__.__name__)
+        insert_txt = f"<caption>{self.__class__.__name__}</caption>\n"
         return insert_before_substring(insert_txt, "<thead>", html_txt)
 
     @overload
     def to_string(
         self,
         buf: None = None,
-        columns: Union[Axes, None] = ...,
-        col_space: Union[int, list[int], dict[Hashable, int], None] = ...,
-        header: Union[bool, SequenceNotStr[str]] = ...,
+        columns: Axes | None = ...,
+        col_space: int | list[int] | dict[Hashable, int] | None = ...,
+        header: bool | SequenceNotStr[str] = ...,
         index: bool = ...,
         na_rep: str = ...,
-        formatters: Union[FormattersType, None] = ...,
-        float_format: Union[FloatFormatType, None] = ...,
-        sparsify: Union[bool, None] = ...,
+        formatters: FormattersType | None = ...,
+        float_format: FloatFormatType | None = ...,
+        sparsify: bool | None = ...,
         index_names: bool = ...,
-        justify: Union[str, None] = ...,
-        line_width: Union[int, None] = ...,
-        max_rows: Union[int, None] = ...,
-        max_cols: Union[int, None] = ...,
+        justify: str | None = ...,
+        line_width: int | None = ...,
+        max_rows: int | None = ...,
+        max_cols: int | None = ...,
         show_dimensions: bool = ...,
     ) -> str: ...
 
     @overload
     def to_string(
         self,
-        buf: Union[WriteBuffer[str], PathLike] = ...,
-        columns: Union[Axes, None] = ...,
-        col_space: Union[int, list[int], dict[Hashable, int], None] = ...,
-        header: Union[bool, SequenceNotStr[str]] = ...,
+        buf: WriteBuffer[str] | PathLike = ...,
+        columns: Axes | None = ...,
+        col_space: int | list[int] | dict[Hashable, int] | None = ...,
+        header: bool | SequenceNotStr[str] = ...,
         index: bool = ...,
         na_rep: str = ...,
-        formatters: Union[FormattersType, None] = ...,
-        float_format: Union[FloatFormatType, None] = ...,
-        sparsify: Union[bool, None] = ...,
+        formatters: FormattersType | None = ...,
+        float_format: FloatFormatType | None = ...,
+        sparsify: bool | None = ...,
         index_names: bool = ...,
-        justify: Union[str, None] = ...,
-        line_width: Union[int, None] = ...,
-        max_rows: Union[int, None] = ...,
-        max_cols: Union[int, None] = ...,
+        justify: str | None = ...,
+        line_width: int | None = ...,
+        max_rows: int | None = ...,
+        max_cols: int | None = ...,
         show_dimensions: bool = ...,
     ) -> None: ...
 
     def to_string(
         self,
-        buf: Union[WriteBuffer[str], PathLike, None] = None,
-        columns: Union[Axes, None] = None,
-        col_space: Union[int, list[int], dict[Hashable, int], None] = None,
-        header: Union[bool, SequenceNotStr[str]] = True,
+        buf: WriteBuffer[str] | PathLike | None = None,
+        columns: Axes | None = None,
+        col_space: int | list[int] | dict[Hashable, int] | None = None,
+        header: bool | SequenceNotStr[str] = True,
         index: bool = True,
         na_rep: str = "NaN",
-        formatters: Union[FormattersType, None] = None,
-        float_format: Union[FloatFormatType, None] = None,
-        sparsify: Union[bool, None] = None,
+        formatters: FormattersType | None = None,
+        float_format: FloatFormatType | None = None,
+        sparsify: bool | None = None,
         index_names: bool = True,
-        justify: Union[str, None] = None,
-        line_width: Union[int, None] = None,
-        max_rows: Union[int, None] = None,
-        max_cols: Union[int, None] = None,
+        justify: str | None = None,
+        line_width: int | None = None,
+        max_rows: int | None = None,
+        max_cols: int | None = None,
         show_dimensions: bool = False,
-    ) -> Union[str, None]:
+    ) -> str | None:
         """Render a DataFrame to a console-friendly tabular output.
 
         Wrapper around the :meth:`pandas.DataFrame.to_string` method.
@@ -159,72 +159,72 @@ class CartesianIO(CartesianCore, GenericIO):
     def to_latex(
         self,
         buf: None = None,
-        columns: Union[Axes, None] = ...,
-        col_space: Union[int, list[int], dict[Hashable, int], None] = ...,
-        header: Union[bool, SequenceNotStr[str]] = ...,
+        columns: Axes | None = ...,
+        col_space: int | list[int] | dict[Hashable, int] | None = ...,
+        header: bool | SequenceNotStr[str] = ...,
         index: bool = ...,
         na_rep: str = ...,
-        formatters: Union[FormattersType, None] = ...,
-        float_format: Union[FloatFormatType, None] = ...,
-        sparsify: Union[bool, None] = ...,
+        formatters: FormattersType | None = ...,
+        float_format: FloatFormatType | None = ...,
+        sparsify: bool | None = ...,
         index_names: bool = ...,
         bold_rows: bool = ...,
-        column_format: Union[str, None] = ...,
-        longtable: Union[bool, None] = ...,
-        escape: Union[bool, None] = ...,
-        encoding: Union[str, None] = ...,
+        column_format: str | None = ...,
+        longtable: bool | None = ...,
+        escape: bool | None = ...,
+        encoding: str | None = ...,
         decimal: str = ...,
-        multicolumn: Union[bool, None] = ...,
-        multicolumn_format: Union[str, None] = ...,
-        multirow: Union[bool, None] = ...,
+        multicolumn: bool | None = ...,
+        multicolumn_format: str | None = ...,
+        multirow: bool | None = ...,
     ) -> str: ...
 
     @overload
     def to_latex(
         self,
-        buf: Union[WriteBuffer[str], PathLike] = ...,
-        columns: Union[Axes, None] = ...,
-        col_space: Union[int, list[int], dict[Hashable, int], None] = ...,
-        header: Union[bool, SequenceNotStr[str]] = ...,
+        buf: WriteBuffer[str] | PathLike = ...,
+        columns: Axes | None = ...,
+        col_space: int | list[int] | dict[Hashable, int] | None = ...,
+        header: bool | SequenceNotStr[str] = ...,
         index: bool = ...,
         na_rep: str = ...,
-        formatters: Union[FormattersType, None] = ...,
-        float_format: Union[FloatFormatType, None] = ...,
-        sparsify: Union[bool, None] = ...,
+        formatters: FormattersType | None = ...,
+        float_format: FloatFormatType | None = ...,
+        sparsify: bool | None = ...,
         index_names: bool = ...,
         bold_rows: bool = ...,
-        column_format: Union[str, None] = ...,
-        longtable: Union[bool, None] = ...,
-        escape: Union[bool, None] = ...,
-        encoding: Union[str, None] = ...,
+        column_format: str | None = ...,
+        longtable: bool | None = ...,
+        escape: bool | None = ...,
+        encoding: str | None = ...,
         decimal: str = ...,
-        multicolumn: Union[bool, None] = ...,
-        multicolumn_format: Union[str, None] = ...,
-        multirow: Union[bool, None] = ...,
+        multicolumn: bool | None = ...,
+        multicolumn_format: str | None = ...,
+        multirow: bool | None = ...,
     ) -> None: ...
 
     def to_latex(
         self,
-        buf: Union[WriteBuffer[str], PathLike, None] = None,
-        columns: Union[Axes, None] = None,
-        col_space: Union[int, list[int], dict[Hashable, int], None] = None,
-        header: Union[bool, SequenceNotStr[str]] = True,
+        buf: WriteBuffer[str] | PathLike | None = None,
+        columns: Axes | None = None,
+        col_space: int | list[int] | dict[Hashable, int] | None = None,
+        header: bool | SequenceNotStr[str] = True,
         index: bool = True,
         na_rep: str = "NaN",
-        formatters: Union[FormattersType, None] = None,
-        float_format: Union[FloatFormatType, None] = None,
-        sparsify: Union[bool, None] = None,
+        formatters: FormattersType | None = None,
+        float_format: FloatFormatType | None = None,
+        sparsify: bool | None = None,
         index_names: bool = True,
         bold_rows: bool = True,
-        column_format: Union[str, None] = None,
-        longtable: Union[bool, None] = None,
-        escape: Union[bool, None] = None,
-        encoding: Union[str, None] = None,
+        column_format: str | None = None,
+        longtable: bool | None = None,
+        escape: bool | None = None,
+        encoding: str | None = None,
         decimal: str = ".",
-        multicolumn: Union[bool, None] = None,
-        multicolumn_format: Union[str, None] = None,
-        multirow: Union[bool, None] = None,
-    ) -> Union[str, None]:
+        multicolumn: bool | None = None,
+        multicolumn_format: str | None = None,
+        multirow: bool | None = None,
+    ) -> str | None:
         """Render a DataFrame to a tabular environment table.
 
         You can splice this into a LaTeX document.
@@ -259,7 +259,7 @@ class CartesianIO(CartesianCore, GenericIO):
         buf: None = None,
         sort_index: bool = ...,
         index: bool = ...,
-        header: Union[bool, SequenceNotStr[str]] = ...,
+        header: bool | SequenceNotStr[str] = ...,
         float_format: FloatFormatType = ...,
         overwrite: bool = ...,
     ) -> str: ...
@@ -270,20 +270,20 @@ class CartesianIO(CartesianCore, GenericIO):
         buf: PathLike = ...,
         sort_index: bool = ...,
         index: bool = ...,
-        header: Union[bool, SequenceNotStr[str]] = ...,
+        header: bool | SequenceNotStr[str] = ...,
         float_format: FloatFormatType = ...,
         overwrite: bool = ...,
     ) -> None: ...
 
     def to_xyz(
         self,
-        buf: Union[PathLike, None] = None,
+        buf: PathLike | None = None,
         sort_index: bool = True,
         index: bool = False,
-        header: Union[bool, SequenceNotStr[str]] = False,
+        header: bool | SequenceNotStr[str] = False,
         float_format: FloatFormatType = "{:.6f}".format,
         overwrite: bool = True,
-    ) -> Union[str, None]:
+    ) -> str | None:
         """Write xyz-file
 
         Args:
@@ -345,11 +345,11 @@ class CartesianIO(CartesianCore, GenericIO):
     @classmethod
     def read_xyz(
         cls,
-        buf: Union[ReadCsvBuffer[str], PathLike],
+        buf: ReadCsvBuffer[str] | PathLike,
         start_index: int = 0,
         get_bonds: bool = True,
-        nrows: Union[int, None] = None,
-        engine: Union[Literal["c", "python", "pyarrow", "python-fwf"], None] = None,
+        nrows: int | None = None,
+        engine: Literal["c", "python", "pyarrow", "python-fwf"] | None = None,
     ) -> Self:
         """Read a file of coordinate information.
 
@@ -401,8 +401,8 @@ class CartesianIO(CartesianCore, GenericIO):
     def to_cjson(self, buf: PathLike = ..., **kwargs: Any) -> None: ...
 
     def to_cjson(
-        self, buf: Union[PathLike, None] = None, **kwargs: Any
-    ) -> Union[dict[str, Any], None]:
+        self, buf: PathLike | None = None, **kwargs: Any
+    ) -> dict[str, Any] | None:
         """Write a cjson file or return dictionary.
 
         The cjson format is specified
@@ -451,7 +451,7 @@ class CartesianIO(CartesianCore, GenericIO):
             return None
 
     @classmethod
-    def read_cjson(cls, buf: Union[dict[str, Any], PathLike]) -> Self:
+    def read_cjson(cls, buf: dict[str, Any] | PathLike) -> Self:
         """Read a cjson file or a dictionary.
 
         The cjson format is specified
@@ -468,7 +468,7 @@ class CartesianIO(CartesianCore, GenericIO):
         if isinstance(buf, dict):
             data = buf.copy()
         else:
-            with open(buf, "r") as f:
+            with open(buf) as f:
                 data = json.load(f)
             assert data["chemical json"] == 0
 
@@ -508,9 +508,7 @@ class CartesianIO(CartesianCore, GenericIO):
             metadata=metadata,
         )
 
-    def view(
-        self, viewer: Union[PathLike, None] = None, use_curr_dir: bool = False
-    ) -> None:
+    def view(self, viewer: PathLike | None = None, use_curr_dir: bool = False) -> None:
         """View your molecule.
 
         .. note:: This function writes a temporary file and opens it with

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_pandas_wrapper.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_pandas_wrapper.py
@@ -1,6 +1,6 @@
 import copy
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Final, Literal, Union, overload
+from typing import TYPE_CHECKING, Any, Final, Literal, overload
 
 from pandas._typing import IndexLabel
 from pandas.core.frame import DataFrame
@@ -39,8 +39,8 @@ class PandasWrapper(indexers.Molecule):
     def __init__(
         self,
         frame: DataFrame,
-        metadata: Union[dict, None] = None,
-        _metadata: Union[dict, None] = None,
+        metadata: dict | None = None,
+        _metadata: dict | None = None,
     ) -> None:
         if not isinstance(frame, DataFrame):
             raise TypeError("frame has to be a pandas DataFrame")
@@ -196,7 +196,7 @@ class PandasWrapper(indexers.Molecule):
         return self._frame.index
 
     @index.setter
-    def index(self, value: Union[Index, SequenceNotStr]) -> None:
+    def index(self, value: Index | SequenceNotStr) -> None:
         self._frame.index = value  # type: ignore[assignment]
 
     @property
@@ -208,7 +208,7 @@ class PandasWrapper(indexers.Molecule):
         return self._frame.columns
 
     @columns.setter
-    def columns(self, value: Union[Index, SequenceNotStr[str]]) -> None:
+    def columns(self, value: Index | SequenceNotStr[str]) -> None:
         if not self._required_cols <= set(value):
             raise PhysicalMeaning(
                 "There are columns missing for a meaningful description of a molecule"
@@ -226,8 +226,8 @@ class PandasWrapper(indexers.Molecule):
     @overload
     def sort_values(
         self,
-        by: Union[str, Sequence[str]],
-        axis: Union[Literal["index", 0], Literal["columns", 1]] = ...,
+        by: str | Sequence[str],
+        axis: Literal["index", 0] | Literal["columns", 1] = ...,
         ascending: bool = ...,
         inplace: Literal[False] = False,
         kind: Literal["quicksort", "mergesort", "heapsort", "stable"] = ...,
@@ -237,8 +237,8 @@ class PandasWrapper(indexers.Molecule):
     @overload
     def sort_values(
         self,
-        by: Union[str, Sequence[str]],
-        axis: Union[Literal["index", 0], Literal["columns", 1]] = ...,
+        by: str | Sequence[str],
+        axis: Literal["index", 0] | Literal["columns", 1] = ...,
         ascending: bool = ...,
         inplace: Literal[True] = ...,
         kind: Literal["quicksort", "mergesort", "heapsort", "stable"] = ...,
@@ -247,13 +247,13 @@ class PandasWrapper(indexers.Molecule):
 
     def sort_values(
         self,
-        by: Union[str, Sequence[str]],
-        axis: Union[Literal["index", 0], Literal["columns", 1]] = 0,
+        by: str | Sequence[str],
+        axis: Literal["index", 0] | Literal["columns", 1] = 0,
         ascending: bool = True,
         inplace: bool = False,
         kind: Literal["quicksort", "mergesort", "heapsort", "stable"] = "quicksort",
         na_position: Literal["first", "last"] = "last",
-    ) -> Union[Self, None]:
+    ) -> Self | None:
         """Sort by the values along either axis
 
         Wrapper around the :meth:`pandas.DataFrame.sort_values` method.
@@ -286,8 +286,8 @@ class PandasWrapper(indexers.Molecule):
     @overload
     def sort_index(
         self,
-        axis: Union[Literal["index", 0], Literal["columns", 1]] = ...,
-        level: Union[IndexLabel, None] = ...,
+        axis: Literal["index", 0] | Literal["columns", 1] = ...,
+        level: IndexLabel | None = ...,
         ascending: bool = ...,
         inplace: Literal[False] = False,
         kind: Literal["quicksort", "mergesort", "heapsort", "stable"] = ...,
@@ -298,8 +298,8 @@ class PandasWrapper(indexers.Molecule):
     @overload
     def sort_index(
         self,
-        axis: Union[Literal["index", 0], Literal["columns", 1]] = ...,
-        level: Union[IndexLabel, None] = ...,
+        axis: Literal["index", 0] | Literal["columns", 1] = ...,
+        level: IndexLabel | None = ...,
         ascending: bool = ...,
         inplace: Literal[True] = ...,
         kind: Literal["quicksort", "mergesort", "heapsort", "stable"] = ...,
@@ -309,14 +309,14 @@ class PandasWrapper(indexers.Molecule):
 
     def sort_index(
         self,
-        axis: Union[Literal["index", 0], Literal["columns", 1]] = 0,
-        level: Union[IndexLabel, None] = None,
+        axis: Literal["index", 0] | Literal["columns", 1] = 0,
+        level: IndexLabel | None = None,
         ascending: bool = True,
         inplace: bool = False,
         kind: Literal["quicksort", "mergesort", "heapsort", "stable"] = "quicksort",
         na_position: Literal["first", "last"] = "last",
         sort_remaining: bool = True,
-    ) -> Union[Self, None]:
+    ) -> Self | None:
         """Sort object by labels (along an axis)
 
         Wrapper around the :meth:`pandas.DataFrame.sort_index` method.
@@ -402,7 +402,7 @@ class PandasWrapper(indexers.Molecule):
                 assert type(keys) is not str
                 dropped_cols = set(keys)
             except (TypeError, AssertionError):
-                dropped_cols = set([keys])
+                dropped_cols = {keys}
 
         if not self._required_cols <= (set(self.columns) - set(dropped_cols)):
             raise PhysicalMeaning(

--- a/src/chemcoord/_cartesian_coordinates/_indexers.py
+++ b/src/chemcoord/_cartesian_coordinates/_indexers.py
@@ -1,13 +1,13 @@
 import warnings
 from abc import abstractmethod
 from collections.abc import Set
-from typing import Generic, TypeVar, Union, overload
+from typing import Generic, TypeAlias, TypeVar, Union, overload
 
 from attrs import define
 from pandas.core.frame import DataFrame
 from pandas.core.indexes.base import Index
 from pandas.core.series import Series
-from typing_extensions import Self, TypeAlias
+from typing_extensions import Self
 
 from chemcoord._generic_classes.generic_core import GenericCore
 from chemcoord._utilities._temporary_deprecation_workarounds import is_iterable
@@ -19,8 +19,8 @@ from chemcoord.typing import Integral, SequenceNotStr, Vector
 class Molecule(GenericCore):
     @abstractmethod
     def _return_appropiate_type(
-        self, selected: Union[Series, DataFrame]
-    ) -> Union[Self, Series, DataFrame]: ...
+        self, selected: Series | DataFrame
+    ) -> Self | Series | DataFrame: ...
 
 
 T = TypeVar("T", bound=Molecule)
@@ -45,29 +45,39 @@ class _Loc(_generic_Indexer, Generic[T]):
     @overload
     def __getitem__(
         self,
-        key: Union[
-            Index, Set[Integral], Vector, SequenceNotStr[Integral], slice, Series
-        ],
+        key: (
+            Index | Set[Integral] | Vector | SequenceNotStr[Integral] | slice | Series
+        ),
     ) -> T: ...
 
     @overload
     def __getitem__(
         self,
         key: tuple[
-            Union[
-                Index, Set[Integral], Vector, SequenceNotStr[Integral], slice, Series
-            ],
-            Union[Index, Set[str], Vector, SequenceNotStr[str], Series],
+            (
+                Index
+                | Set[Integral]
+                | Vector
+                | SequenceNotStr[Integral]
+                | slice
+                | Series
+            ),
+            Index | Set[str] | Vector | SequenceNotStr[str] | Series,
         ],
-    ) -> Union[T, DataFrame]: ...
+    ) -> T | DataFrame: ...
 
     @overload
     def __getitem__(
         self,
         key: tuple[
-            Union[
-                Index, Set[Integral], Vector, SequenceNotStr[Integral], slice, Series
-            ],
+            (
+                Index
+                | Set[Integral]
+                | Vector
+                | SequenceNotStr[Integral]
+                | slice
+                | Series
+            ),
             slice,
         ],
     ) -> T: ...
@@ -76,9 +86,14 @@ class _Loc(_generic_Indexer, Generic[T]):
     def __getitem__(
         self,
         key: tuple[
-            Union[
-                Index, Set[Integral], Vector, SequenceNotStr[Integral], slice, Series
-            ],
+            (
+                Index
+                | Set[Integral]
+                | Vector
+                | SequenceNotStr[Integral]
+                | slice
+                | Series
+            ),
             str,
         ],
     ) -> Series: ...
@@ -88,42 +103,42 @@ class _Loc(_generic_Indexer, Generic[T]):
         self,
         key: tuple[
             Integral,
-            Union[Index, Set[str], Vector, SequenceNotStr[str], slice, Series],
+            Index | Set[str] | Vector | SequenceNotStr[str] | slice | Series,
         ],
-    ) -> Union[T, Series]: ...
+    ) -> T | Series: ...
 
     @overload
     def __getitem__(
         self,
         key: tuple[Integral, str],
-    ) -> Union[float, str]: ...
+    ) -> float | str: ...
 
     def __getitem__(
         self,
-        key: Union[
-            Union[
-                Integral,
-                Index,
-                Set[Integral],
-                Vector,
-                SequenceNotStr[Integral],
-                slice,
-                Series,
-            ],
-            tuple[
-                Union[
-                    Integral,
-                    Index,
-                    Set[Integral],
-                    Vector,
-                    SequenceNotStr[Integral],
-                    slice,
-                    Series,
-                ],
-                Union[str, Index, Set[str], Vector, SequenceNotStr[str], slice, Series],
-            ],
-        ],
-    ) -> Union[T, DataFrame, Series, float, str]:
+        key: (
+            (
+                Integral
+                | Index
+                | Set[Integral]
+                | Vector
+                | SequenceNotStr[Integral]
+                | slice
+                | Series
+            )
+            | tuple[
+                (
+                    Integral
+                    | Index
+                    | Set[Integral]
+                    | Vector
+                    | SequenceNotStr[Integral]
+                    | slice
+                    | Series
+                ),
+                str | Index | Set[str] | Vector | SequenceNotStr[str] | slice | Series,
+            ]
+        ),
+    ) -> T | DataFrame | Series | float | str:
         if isinstance(key, tuple):
             selected = self.molecule._frame.loc[
                 _set_caster(key[0]), _set_caster(key[1])
@@ -138,13 +153,13 @@ class _Loc(_generic_Indexer, Generic[T]):
 
     def __setitem__(
         self,
-        key: Union[
-            IntIdx,
-            slice,
-            Series,
-            Index,
-            tuple[Union[Series, IntIdx, slice, Index], Union[Series, StrIdx, slice]],
-        ],
+        key: (
+            IntIdx
+            | slice
+            | Series
+            | Index
+            | tuple[Series | IntIdx | slice | Index, Series | StrIdx | slice]
+        ),
         value,
     ) -> None:
         df = self.molecule._frame
@@ -186,29 +201,39 @@ class _ILoc(_generic_Indexer, Generic[T]):
     @overload
     def __getitem__(
         self,
-        key: Union[
-            Index, Set[Integral], Vector, SequenceNotStr[Integral], slice, Series
-        ],
+        key: (
+            Index | Set[Integral] | Vector | SequenceNotStr[Integral] | slice | Series
+        ),
     ) -> T: ...
 
     @overload
     def __getitem__(
         self,
         key: tuple[
-            Union[
-                Index, Set[Integral], Vector, SequenceNotStr[Integral], slice, Series
-            ],
-            Union[Index, Set[Integral], Vector, SequenceNotStr[Integral], Series],
+            (
+                Index
+                | Set[Integral]
+                | Vector
+                | SequenceNotStr[Integral]
+                | slice
+                | Series
+            ),
+            Index | Set[Integral] | Vector | SequenceNotStr[Integral] | Series,
         ],
-    ) -> Union[T, DataFrame]: ...
+    ) -> T | DataFrame: ...
 
     @overload
     def __getitem__(
         self,
         key: tuple[
-            Union[
-                Index, Set[Integral], Vector, SequenceNotStr[Integral], slice, Series
-            ],
+            (
+                Index
+                | Set[Integral]
+                | Vector
+                | SequenceNotStr[Integral]
+                | slice
+                | Series
+            ),
             slice,
         ],
     ) -> T: ...
@@ -217,9 +242,14 @@ class _ILoc(_generic_Indexer, Generic[T]):
     def __getitem__(
         self,
         key: tuple[
-            Union[
-                Index, Set[Integral], Vector, SequenceNotStr[Integral], slice, Series
-            ],
+            (
+                Index
+                | Set[Integral]
+                | Vector
+                | SequenceNotStr[Integral]
+                | slice
+                | Series
+            ),
             Integral,
         ],
     ) -> Series: ...
@@ -229,52 +259,57 @@ class _ILoc(_generic_Indexer, Generic[T]):
         self,
         key: tuple[
             Integral,
-            Union[
-                Index, Set[Integral], Vector, SequenceNotStr[Integral], slice, Series
-            ],
+            (
+                Index
+                | Set[Integral]
+                | Vector
+                | SequenceNotStr[Integral]
+                | slice
+                | Series
+            ),
         ],
-    ) -> Union[T, Series]: ...
+    ) -> T | Series: ...
 
     @overload
     def __getitem__(
         self,
         key: tuple[Integral, Integral],
-    ) -> Union[float, str]: ...
+    ) -> float | str: ...
 
     def __getitem__(
         self,
-        key: Union[
-            Union[
-                Integral,
-                Index,
-                Set[Integral],
-                Vector,
-                SequenceNotStr[Integral],
-                slice,
-                Series,
-            ],
-            tuple[
-                Union[
-                    Integral,
-                    Index,
-                    Set[Integral],
-                    Vector,
-                    SequenceNotStr[Integral],
-                    slice,
-                    Series,
-                ],
-                Union[
-                    Integral,
-                    Index,
-                    Set[Integral],
-                    Vector,
-                    SequenceNotStr[Integral],
-                    slice,
-                    Series,
-                ],
-            ],
-        ],
-    ) -> Union[T, DataFrame, Series, float, str]:
+        key: (
+            (
+                Integral
+                | Index
+                | Set[Integral]
+                | Vector
+                | SequenceNotStr[Integral]
+                | slice
+                | Series
+            )
+            | tuple[
+                (
+                    Integral
+                    | Index
+                    | Set[Integral]
+                    | Vector
+                    | SequenceNotStr[Integral]
+                    | slice
+                    | Series
+                ),
+                (
+                    Integral
+                    | Index
+                    | Set[Integral]
+                    | Vector
+                    | SequenceNotStr[Integral]
+                    | slice
+                    | Series
+                ),
+            ]
+        ),
+    ) -> T | DataFrame | Series | float | str:
         if isinstance(key, tuple):
             selected = self.molecule._frame.iloc[
                 _set_caster(key[0]), _set_caster(key[1])
@@ -288,12 +323,12 @@ class _ILoc(_generic_Indexer, Generic[T]):
 
     def __setitem__(
         self,
-        key: Union[
-            IntIdx,
-            slice,
-            Series,
-            tuple[Union[Series, IntIdx, slice], Union[Series, IntIdx, slice]],
-        ],
+        key: (
+            IntIdx
+            | slice
+            | Series
+            | tuple[Series | IntIdx | slice, Series | IntIdx | slice]
+        ),
         value,
     ) -> None:
         df = self.molecule._frame

--- a/src/chemcoord/_cartesian_coordinates/point_group.py
+++ b/src/chemcoord/_cartesian_coordinates/point_group.py
@@ -21,7 +21,7 @@ class PointGroupOperations(list):
         self, sch_symbol: str, operations: Sequence[SymmOp], tolerance: float = 0.1
     ) -> None:
         self.sch_symbol = sch_symbol
-        super(PointGroupOperations, self).__init__(
+        super().__init__(
             [op.rotation_matrix for op in generate_full_symmops(operations, tolerance)]
         )
 

--- a/src/chemcoord/_cartesian_coordinates/xyz_functions.py
+++ b/src/chemcoord/_cartesian_coordinates/xyz_functions.py
@@ -3,9 +3,9 @@ import os
 import subprocess
 import tempfile
 import warnings
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from threading import Thread
-from typing import Callable, Union, overload
+from typing import overload
 
 import numpy as np
 import pandas as pd
@@ -25,8 +25,8 @@ from chemcoord.typing import Matrix, PathLike, Real, Tensor4D, Vector
 
 
 def view(
-    molecule: Union[Cartesian, Sequence[Cartesian]],
-    viewer: Union[PathLike, None] = None,
+    molecule: Cartesian | Sequence[Cartesian],
+    viewer: PathLike | None = None,
     use_curr_dir: bool = False,
 ) -> None:
     """View your molecule or list of molecules.
@@ -106,11 +106,11 @@ def to_molden(
 
 def to_molden(
     cartesian_list: Sequence[Cartesian],
-    buf: Union[PathLike, None] = None,
+    buf: PathLike | None = None,
     sort_index: bool = True,
     overwrite: bool = True,
     float_format: Callable[[float], str] = "{:.6f}".format,
-) -> Union[str, None]:
+) -> str | None:
     """Write a list of Cartesians into a molden file.
 
     .. note:: Since it permamently writes a file, this function
@@ -191,7 +191,7 @@ def read_molden(
     Returns:
         list: A list containing :class:`~chemcoord.Cartesian` is returned.
     """
-    with open(inputfile, "r") as f:
+    with open(inputfile) as f:
         found = False
         while not found:
             line = f.readline()
@@ -305,7 +305,7 @@ def allclose(
 def concat(
     cartesians: Sequence[Cartesian],
     ignore_index: bool = False,
-    keys: Union[Iterable, None] = None,
+    keys: Iterable | None = None,
 ) -> Cartesian:
     """Join list of cartesians into one molecule.
 
@@ -420,7 +420,7 @@ def orthonormalize_righthanded(basis: Matrix[np.floating]) -> Matrix[np.float64]
 def get_kabsch_rotation(
     Q: Matrix[np.floating],
     P: Matrix[np.floating],
-    weights: Union[Vector[np.floating], None] = None,
+    weights: Vector[np.floating] | None = None,
 ) -> Matrix[np.float64]:
     """Calculate the optimal rotation from ``P`` unto ``Q``.
 

--- a/src/chemcoord/_generic_classes/generic_IO.py
+++ b/src/chemcoord/_generic_classes/generic_IO.py
@@ -7,7 +7,7 @@ class GenericIO:
     def _sympy_formatter(self) -> Self:
         def formatter(x):
             if isinstance(x, sympy.Basic):
-                return "${}$".format(sympy.latex(x))
+                return f"${sympy.latex(x)}$"
             else:
                 return x
 

--- a/src/chemcoord/_internal_coordinates/_indexers.py
+++ b/src/chemcoord/_internal_coordinates/_indexers.py
@@ -1,13 +1,12 @@
 import warnings
 from abc import abstractmethod
 from collections.abc import Set
-from typing import Generic, TypeVar, Union, overload
+from typing import Generic, TypeAlias, TypeVar, Union, overload
 
 from attrs import define
 from pandas.core.frame import DataFrame
 from pandas.core.indexes.base import Index
 from pandas.core.series import Series
-from typing_extensions import TypeAlias
 
 from chemcoord._generic_classes.generic_core import GenericCore
 from chemcoord._utilities._temporary_deprecation_workarounds import is_iterable
@@ -51,8 +50,24 @@ class _Loc(_generic_Indexer):
     @overload
     def __getitem__(
         self,
-        key: Union[
-            Index, Set[Integral], Vector, SequenceNotStr[Integral], slice, Series
+        key: (
+            Index | Set[Integral] | Vector | SequenceNotStr[Integral] | slice | Series
+        ),
+    ) -> DataFrame: ...
+
+    @overload
+    def __getitem__(
+        self,
+        key: tuple[
+            (
+                Index
+                | Set[Integral]
+                | Vector
+                | SequenceNotStr[Integral]
+                | slice
+                | Series
+            ),
+            Index | Set[str] | Vector | SequenceNotStr[str] | slice | Series,
         ],
     ) -> DataFrame: ...
 
@@ -60,20 +75,14 @@ class _Loc(_generic_Indexer):
     def __getitem__(
         self,
         key: tuple[
-            Union[
-                Index, Set[Integral], Vector, SequenceNotStr[Integral], slice, Series
-            ],
-            Union[Index, Set[str], Vector, SequenceNotStr[str], slice, Series],
-        ],
-    ) -> DataFrame: ...
-
-    @overload
-    def __getitem__(
-        self,
-        key: tuple[
-            Union[
-                Index, Set[Integral], Vector, SequenceNotStr[Integral], slice, Series
-            ],
+            (
+                Index
+                | Set[Integral]
+                | Vector
+                | SequenceNotStr[Integral]
+                | slice
+                | Series
+            ),
             str,
         ],
     ) -> Series: ...
@@ -83,7 +92,7 @@ class _Loc(_generic_Indexer):
         self,
         key: tuple[
             Integral,
-            Union[Index, Set[str], Vector, SequenceNotStr[str], slice, Series],
+            Index | Set[str] | Vector | SequenceNotStr[str] | slice | Series,
         ],
     ) -> Series: ...
 
@@ -91,34 +100,34 @@ class _Loc(_generic_Indexer):
     def __getitem__(
         self,
         key: tuple[Integral, str],
-    ) -> Union[float, str]: ...
+    ) -> float | str: ...
 
     def __getitem__(
         self,
-        key: Union[
-            Union[
-                Integral,
-                Index,
-                Set[Integral],
-                Vector,
-                SequenceNotStr[Integral],
-                slice,
-                Series,
-            ],
-            tuple[
-                Union[
-                    Integral,
-                    Index,
-                    Set[Integral],
-                    Vector,
-                    SequenceNotStr[Integral],
-                    slice,
-                    Series,
-                ],
-                Union[str, Index, Set[str], Vector, SequenceNotStr[str], slice, Series],
-            ],
-        ],
-    ) -> Union[Series, DataFrame, float, str]:
+        key: (
+            (
+                Integral
+                | Index
+                | Set[Integral]
+                | Vector
+                | SequenceNotStr[Integral]
+                | slice
+                | Series
+            )
+            | tuple[
+                (
+                    Integral
+                    | Index
+                    | Set[Integral]
+                    | Vector
+                    | SequenceNotStr[Integral]
+                    | slice
+                    | Series
+                ),
+                str | Index | Set[str] | Vector | SequenceNotStr[str] | slice | Series,
+            ]
+        ),
+    ) -> Series | DataFrame | float | str:
         indexer = getattr(self.molecule._frame, self._get_idxer())
         if isinstance(key, tuple):
             selected = indexer[key[0], key[1]]
@@ -141,8 +150,31 @@ class _ILoc(_generic_Indexer):
     @overload
     def __getitem__(
         self,
-        key: Union[
-            Index, Set[Integral], Vector, SequenceNotStr[Integral], slice, Series
+        key: (
+            Index | Set[Integral] | Vector | SequenceNotStr[Integral] | slice | Series
+        ),
+    ) -> DataFrame: ...
+
+    @overload
+    def __getitem__(
+        self,
+        key: tuple[
+            (
+                Index
+                | Set[Integral]
+                | Vector
+                | SequenceNotStr[Integral]
+                | slice
+                | Series
+            ),
+            (
+                Index
+                | Set[Integral]
+                | Vector
+                | SequenceNotStr[Integral]
+                | slice
+                | Series
+            ),
         ],
     ) -> DataFrame: ...
 
@@ -150,22 +182,14 @@ class _ILoc(_generic_Indexer):
     def __getitem__(
         self,
         key: tuple[
-            Union[
-                Index, Set[Integral], Vector, SequenceNotStr[Integral], slice, Series
-            ],
-            Union[
-                Index, Set[Integral], Vector, SequenceNotStr[Integral], slice, Series
-            ],
-        ],
-    ) -> DataFrame: ...
-
-    @overload
-    def __getitem__(
-        self,
-        key: tuple[
-            Union[
-                Index, Set[Integral], Vector, SequenceNotStr[Integral], slice, Series
-            ],
+            (
+                Index
+                | Set[Integral]
+                | Vector
+                | SequenceNotStr[Integral]
+                | slice
+                | Series
+            ),
             Integral,
         ],
     ) -> Series: ...
@@ -175,9 +199,14 @@ class _ILoc(_generic_Indexer):
         self,
         key: tuple[
             Integral,
-            Union[
-                Index, Set[Integral], Vector, SequenceNotStr[Integral], slice, Series
-            ],
+            (
+                Index
+                | Set[Integral]
+                | Vector
+                | SequenceNotStr[Integral]
+                | slice
+                | Series
+            ),
         ],
     ) -> Series: ...
 
@@ -185,42 +214,42 @@ class _ILoc(_generic_Indexer):
     def __getitem__(
         self,
         key: tuple[Integral, Integral],
-    ) -> Union[float, str]: ...
+    ) -> float | str: ...
 
     def __getitem__(
         self,
-        key: Union[
-            Union[
-                Integral,
-                Index,
-                Set[Integral],
-                Vector,
-                SequenceNotStr[Integral],
-                slice,
-                Series,
-            ],
-            tuple[
-                Union[
-                    Integral,
-                    Index,
-                    Set[Integral],
-                    Vector,
-                    SequenceNotStr[Integral],
-                    slice,
-                    Series,
-                ],
-                Union[
-                    Integral,
-                    Index,
-                    Set[Integral],
-                    Vector,
-                    SequenceNotStr[Integral],
-                    slice,
-                    Series,
-                ],
-            ],
-        ],
-    ) -> Union[Series, DataFrame, float, str]:
+        key: (
+            (
+                Integral
+                | Index
+                | Set[Integral]
+                | Vector
+                | SequenceNotStr[Integral]
+                | slice
+                | Series
+            )
+            | tuple[
+                (
+                    Integral
+                    | Index
+                    | Set[Integral]
+                    | Vector
+                    | SequenceNotStr[Integral]
+                    | slice
+                    | Series
+                ),
+                (
+                    Integral
+                    | Index
+                    | Set[Integral]
+                    | Vector
+                    | SequenceNotStr[Integral]
+                    | slice
+                    | Series
+                ),
+            ]
+        ),
+    ) -> Series | DataFrame | float | str:
         indexer = getattr(self.molecule._frame, self._get_idxer())
         if isinstance(key, tuple):
             selected = indexer[key[0], key[1]]

--- a/src/chemcoord/_internal_coordinates/_zmat_class_core.py
+++ b/src/chemcoord/_internal_coordinates/_zmat_class_core.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import copy
 import warnings
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from functools import partial
 from numbers import Real
-from typing import TYPE_CHECKING, Any, Callable, Literal, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 import numpy as np
 import pandas as pd
@@ -249,7 +249,7 @@ class ZmatCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             new.unsafe_loc[:, coords] = result
         return new
 
-    def __mul__(self, other: Union[Self, Real]) -> Self:
+    def __mul__(self, other: Self | Real) -> Self:
         coords = ["bond", "angle", "dihedral"]
         if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
@@ -267,10 +267,10 @@ class ZmatCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             new.unsafe_loc[:, coords] = result
         return new
 
-    def __rmul__(self, other: Union[Self, Real]) -> Self:
+    def __rmul__(self, other: Self | Real) -> Self:
         return self * other
 
-    def __truediv__(self, other: Union[Self, Real]) -> Self:
+    def __truediv__(self, other: Self | Real) -> Self:
         coords = ["bond", "angle", "dihedral"]
         if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
@@ -288,7 +288,7 @@ class ZmatCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             new.unsafe_loc[:, coords] = result
         return new
 
-    def __rtruediv__(self, other: Union[Self, Real]) -> Self:
+    def __rtruediv__(self, other: Self | Real) -> Self:
         coords = ["bond", "angle", "dihedral"]
         if isinstance(other, self.__class__):
             self._test_if_can_be_added(other)
@@ -506,7 +506,7 @@ class ZmatCore(PandasWrapper, GenericCore):  # noqa: PLW1641
                 self._metadata["last_valid_cartesian"] = new_cartesian
         return out
 
-    def change_numbering(self, new_index: Union[Sequence, None] = None) -> Self:
+    def change_numbering(self, new_index: Sequence | None = None) -> Self:
         """Change numbering to a new index.
 
         Changes the numbering of index and all dependent numbering
@@ -669,7 +669,7 @@ class ZmatCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         zmat_values = zmat.get_cartesian()._calculate_zmat_values(c_table)
         zmat.unsafe_loc[to_remove, ["bond", "angle", "dihedral"]] = zmat_values
         zmat._frame.drop([has_dummies[k]["dummy_d"] for k in to_remove], inplace=True)
-        warnings.warn("The dummy atoms {} were removed".format(to_remove), UserWarning)
+        warnings.warn(f"The dummy atoms {to_remove} were removed", UserWarning)
         for k in to_remove:
             zmat._metadata["has_dummies"].pop(k)
         if not inplace:
@@ -742,7 +742,7 @@ class ZmatCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         as_function: Literal[True] = True,
         chain: bool = ...,
         drop_auto_dummies: bool = ...,
-        pure_internal: Union[bool, None] = ...,
+        pure_internal: bool | None = ...,
     ) -> Callable[[Self], Cartesian]: ...
 
     @overload
@@ -751,7 +751,7 @@ class ZmatCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         as_function: Literal[False] = ...,
         chain: bool = ...,
         drop_auto_dummies: bool = ...,
-        pure_internal: Union[bool, None] = ...,
+        pure_internal: bool | None = ...,
     ) -> Tensor4D: ...
 
     def get_grad_cartesian(
@@ -759,8 +759,8 @@ class ZmatCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         as_function: bool = True,
         chain: bool = True,
         drop_auto_dummies: bool = True,
-        pure_internal: Union[bool, None] = None,
-    ) -> Union[Tensor4D, Callable[[Self], Cartesian]]:
+        pure_internal: bool | None = None,
+    ) -> Tensor4D | Callable[[Self], Cartesian]:
         r"""Return the gradient for the transformation to a Cartesian.
 
         If ``as_function`` is True, a function is returned that can be directly

--- a/src/chemcoord/_internal_coordinates/_zmat_class_io.py
+++ b/src/chemcoord/_internal_coordinates/_zmat_class_io.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Literal, Union, overload
+from typing import Literal, overload
 
 import pandas as pd
 from pandas._typing import ReadCsvBuffer
@@ -49,7 +49,7 @@ class ZmatIO(ZmatCore, GenericIO):
             return (insert_txt + substr).join(txt.split(substr))
 
         html_txt = out._frame._repr_html_()
-        insert_txt = "<caption>{}</caption>\n".format(self.__class__.__name__)
+        insert_txt = f"<caption>{self.__class__.__name__}</caption>\n"
         return insert_before_substring(insert_txt, "<thead>", html_txt)
 
     def _remove_upper_triangle(self) -> Self:
@@ -98,17 +98,17 @@ class ZmatIO(ZmatCore, GenericIO):
     @overload
     def to_latex(
         self,
-        buf: Union[WriteBuffer[str], PathLike] = ...,
+        buf: WriteBuffer[str] | PathLike = ...,
         upper_triangle: bool = ...,
         **kwargs,
     ) -> None: ...
 
     def to_latex(
         self,
-        buf: Union[WriteBuffer[str], PathLike, None] = None,
+        buf: WriteBuffer[str] | PathLike | None = None,
         upper_triangle: bool = True,
         **kwargs,
-    ) -> Union[str, None]:
+    ) -> str | None:
         """Render a DataFrame to a tabular environment table.
 
         You can splice this into a LaTeX document.
@@ -123,7 +123,7 @@ class ZmatIO(ZmatCore, GenericIO):
 
     @classmethod
     def read_zmat(
-        cls, inputfile: Union[ReadCsvBuffer[str], PathLike], implicit_index: bool = True
+        cls, inputfile: ReadCsvBuffer[str] | PathLike, implicit_index: bool = True
     ) -> Self:
         """Reads a zmat file.
 
@@ -181,13 +181,13 @@ class ZmatIO(ZmatCore, GenericIO):
 
     def to_zmat(
         self,
-        buf: Union[PathLike, None] = None,
+        buf: PathLike | None = None,
         upper_triangle: bool = True,
         implicit_index: bool = True,
         float_format: FloatFormatType = "{:.6f}".format,
         overwrite: bool = True,
         header: bool = False,
-    ) -> Union[str, None]:
+    ) -> str | None:
         """Write zmat-file
 
         Args:

--- a/src/chemcoord/_utilities/_decorators.py
+++ b/src/chemcoord/_utilities/_decorators.py
@@ -2,7 +2,7 @@
 # and modified. http://pandas.pydata.org/
 from collections.abc import Callable
 from textwrap import dedent
-from typing import TypeVar, Union, overload
+from typing import TypeVar, overload
 
 import numba as nb
 
@@ -118,8 +118,8 @@ def njit(**kwargs) -> Callable[[Function], Function]: ...
 
 
 def njit(
-    f: Union[Function, None] = None, **kwargs
-) -> Union[Function, Callable[[Function], Function]]:
+    f: Function | None = None, **kwargs
+) -> Function | Callable[[Function], Function]:
     """Type-safe jit wrapper that caches the compiled function
 
     With this jit wrapper, you can actually use static typing together with numba.

--- a/src/chemcoord/_utilities/_print_versions.py
+++ b/src/chemcoord/_utilities/_print_versions.py
@@ -114,11 +114,11 @@ def show_versions(as_json=False):
         print("------------------")
 
         for k, stat in sys_info:
-            print("%s: %s" % (k, stat))
+            print("{}: {}".format(k, stat))
 
         print("")
         for k, stat in deps_blob:
-            print("%s: %s" % (k, stat))
+            print("{}: {}".format(k, stat))
 
 
 def main():

--- a/src/chemcoord/typing.py
+++ b/src/chemcoord/typing.py
@@ -11,7 +11,7 @@ i.e. the type is mostly useful to document intent to the developer.
 
 import os
 from collections.abc import Sequence
-from typing import Any, Dict, NewType, Tuple, TypeVar, Union
+from typing import Any, NewType, TypeAlias, TypeVar, Union
 
 import numpy as np
 
@@ -24,7 +24,6 @@ from pandas._typing import (  # noqa: F401
     SequenceNotStr,
     WriteBuffer,
 )
-from typing_extensions import TypeAlias
 
 # We want the dtype to behave covariant, i.e. if a
 #  Vector[float] is allowed, then the more specific
@@ -40,26 +39,26 @@ T_dtype_co = TypeVar("T_dtype_co", bound=np.generic, covariant=True)
 # make the typechecks more strict over time, when shape checking finally comes to numpy.
 
 #: Type annotation of a vector.
-Vector = np.ndarray[Tuple[int], np.dtype[T_dtype_co]]
+Vector = np.ndarray[tuple[int], np.dtype[T_dtype_co]]
 #: Type annotation of a matrix.
-Matrix = np.ndarray[Tuple[int, ...], np.dtype[T_dtype_co]]
+Matrix = np.ndarray[tuple[int, ...], np.dtype[T_dtype_co]]
 #: Type annotation of a tensor.
-Tensor3D = np.ndarray[Tuple[int, ...], np.dtype[T_dtype_co]]
+Tensor3D = np.ndarray[tuple[int, ...], np.dtype[T_dtype_co]]
 #: Type annotation of a tensor.
-Tensor4D = np.ndarray[Tuple[int, ...], np.dtype[T_dtype_co]]
+Tensor4D = np.ndarray[tuple[int, ...], np.dtype[T_dtype_co]]
 #: Type annotation of a tensor.
-Tensor5D = np.ndarray[Tuple[int, ...], np.dtype[T_dtype_co]]
+Tensor5D = np.ndarray[tuple[int, ...], np.dtype[T_dtype_co]]
 #: Type annotation of a tensor.
-Tensor6D = np.ndarray[Tuple[int, ...], np.dtype[T_dtype_co]]
+Tensor6D = np.ndarray[tuple[int, ...], np.dtype[T_dtype_co]]
 #: Type annotation of a tensor.
-Tensor7D = np.ndarray[Tuple[int, ...], np.dtype[T_dtype_co]]
+Tensor7D = np.ndarray[tuple[int, ...], np.dtype[T_dtype_co]]
 #: Type annotation of a tensor.
-Tensor = np.ndarray[Tuple[int, ...], np.dtype[T_dtype_co]]
+Tensor = np.ndarray[tuple[int, ...], np.dtype[T_dtype_co]]
 
 #: Type annotation for pathlike objects.
 PathLike: TypeAlias = Union[str, os.PathLike[str]]
 #: Type annotation for dictionaries holding keyword arguments.
-KwargDict: TypeAlias = Dict[str, Any]
+KwargDict: TypeAlias = dict[str, Any]
 
 
 AtomIdx = NewType("AtomIdx", int)


### PR DESCRIPTION
Upgraded to python 3.10 using `pyupgrade`. 
This allows, in particular, the modern `|` syntanx for union types.