### PR TITLE
fixed docstring reference

### DIFF
--- a/docs/source/cartesian_coordinates.rst
+++ b/docs/source/cartesian_coordinates.rst
@@ -31,6 +31,8 @@ A collection of functions operating on instances of
     ~xyz_functions.isclose
     ~xyz_functions.allclose
     ~xyz_functions.concat
+    ~xyz_functions.to_multiple_xyz
+    ~xyz_functions.read_multiple_xyz
     ~xyz_functions.write_molden
     ~xyz_functions.to_molden
     ~xyz_functions.read_molden


### PR DESCRIPTION
fixed documentation so it shows docstrings for new xyz functions