### PR TITLE
added callable as possible row indexer

### DIFF
--- a/src/chemcoord/_cartesian_coordinates/_indexers.py
+++ b/src/chemcoord/_cartesian_coordinates/_indexers.py
@@ -33,7 +33,7 @@ class _generic_Indexer(Generic[T]):
 
 IntIdx: TypeAlias = Integral | Set[Integral] | Vector | SequenceNotStr[Integral]
 StrIdx: TypeAlias = str | Set[str] | SequenceNotStr[str]
-QueryFunction: TypeAlias = Callable[[DataFrame], Series[bool]]
+QueryFunction: TypeAlias = Callable[[DataFrame], Series]
 
 
 class _Loc(_generic_Indexer, Generic[T]):

--- a/src/chemcoord/_cartesian_coordinates/_indexers.py
+++ b/src/chemcoord/_cartesian_coordinates/_indexers.py
@@ -1,6 +1,6 @@
 import warnings
 from abc import abstractmethod
-from collections.abc import Set
+from collections.abc import Callable, Set
 from typing import Generic, TypeAlias, TypeVar, overload
 
 from attrs import define
@@ -33,6 +33,7 @@ class _generic_Indexer(Generic[T]):
 
 IntIdx: TypeAlias = Integral | Set[Integral] | Vector | SequenceNotStr[Integral]
 StrIdx: TypeAlias = str | Set[str] | SequenceNotStr[str]
+QueryFunction: TypeAlias = Callable[[DataFrame], Series[bool]]
 
 
 class _Loc(_generic_Indexer, Generic[T]):
@@ -46,7 +47,13 @@ class _Loc(_generic_Indexer, Generic[T]):
     def __getitem__(
         self,
         key: (
-            Index | Set[Integral] | Vector | SequenceNotStr[Integral] | slice | Series
+            Index
+            | Set[Integral]
+            | Vector
+            | SequenceNotStr[Integral]
+            | slice
+            | Series
+            | QueryFunction
         ),
     ) -> T: ...
 
@@ -61,6 +68,7 @@ class _Loc(_generic_Indexer, Generic[T]):
                 | SequenceNotStr[Integral]
                 | slice
                 | Series
+                | QueryFunction
             ),
             Index | Set[str] | Vector | SequenceNotStr[str] | Series,
         ],
@@ -77,6 +85,7 @@ class _Loc(_generic_Indexer, Generic[T]):
                 | SequenceNotStr[Integral]
                 | slice
                 | Series
+                | QueryFunction
             ),
             slice,
         ],
@@ -93,6 +102,7 @@ class _Loc(_generic_Indexer, Generic[T]):
                 | SequenceNotStr[Integral]
                 | slice
                 | Series
+                | QueryFunction
             ),
             str,
         ],
@@ -124,6 +134,7 @@ class _Loc(_generic_Indexer, Generic[T]):
                 | SequenceNotStr[Integral]
                 | slice
                 | Series
+                | QueryFunction
             )
             | tuple[
                 (
@@ -134,6 +145,7 @@ class _Loc(_generic_Indexer, Generic[T]):
                     | SequenceNotStr[Integral]
                     | slice
                     | Series
+                    | QueryFunction
                 ),
                 str | Index | Set[str] | Vector | SequenceNotStr[str] | slice | Series,
             ]

--- a/src/chemcoord/_internal_coordinates/_indexers.py
+++ b/src/chemcoord/_internal_coordinates/_indexers.py
@@ -1,6 +1,6 @@
 import warnings
 from abc import abstractmethod
-from collections.abc import Set
+from collections.abc import Callable, Set
 from typing import Generic, TypeAlias, TypeVar, overload
 
 from attrs import define
@@ -25,6 +25,7 @@ T = TypeVar("T", bound=GenericCore)
 
 IntIdx: TypeAlias = Integral | Set[Integral] | Vector | SequenceNotStr[Integral]
 StrIdx: TypeAlias = str | Set[str] | SequenceNotStr[str]
+QueryFunction: TypeAlias = Callable[[DataFrame], Series[bool]]
 
 
 @define
@@ -51,7 +52,13 @@ class _Loc(_generic_Indexer):
     def __getitem__(
         self,
         key: (
-            Index | Set[Integral] | Vector | SequenceNotStr[Integral] | slice | Series
+            Index
+            | Set[Integral]
+            | Vector
+            | SequenceNotStr[Integral]
+            | slice
+            | Series
+            | QueryFunction
         ),
     ) -> DataFrame: ...
 
@@ -66,6 +73,7 @@ class _Loc(_generic_Indexer):
                 | SequenceNotStr[Integral]
                 | slice
                 | Series
+                | QueryFunction
             ),
             Index | Set[str] | Vector | SequenceNotStr[str] | slice | Series,
         ],
@@ -82,6 +90,7 @@ class _Loc(_generic_Indexer):
                 | SequenceNotStr[Integral]
                 | slice
                 | Series
+                | QueryFunction
             ),
             str,
         ],
@@ -113,6 +122,7 @@ class _Loc(_generic_Indexer):
                 | SequenceNotStr[Integral]
                 | slice
                 | Series
+                | QueryFunction
             )
             | tuple[
                 (

--- a/src/chemcoord/_internal_coordinates/_indexers.py
+++ b/src/chemcoord/_internal_coordinates/_indexers.py
@@ -133,6 +133,7 @@ class _Loc(_generic_Indexer):
                     | SequenceNotStr[Integral]
                     | slice
                     | Series
+                    | QueryFunction
                 ),
                 str | Index | Set[str] | Vector | SequenceNotStr[str] | slice | Series,
             ]

--- a/src/chemcoord/_internal_coordinates/_indexers.py
+++ b/src/chemcoord/_internal_coordinates/_indexers.py
@@ -25,7 +25,7 @@ T = TypeVar("T", bound=GenericCore)
 
 IntIdx: TypeAlias = Integral | Set[Integral] | Vector | SequenceNotStr[Integral]
 StrIdx: TypeAlias = str | Set[str] | SequenceNotStr[str]
-QueryFunction: TypeAlias = Callable[[DataFrame], Series[bool]]
+QueryFunction: TypeAlias = Callable[[DataFrame], Series]
 
 
 @define

--- a/tests/cartesian_coordinates/xyz_functions/test_xyz_functions.py
+++ b/tests/cartesian_coordinates/xyz_functions/test_xyz_functions.py
@@ -79,17 +79,22 @@ def test_concat_with_zmats():
 def test_multiple_xyz():
     output_path = os.path.join(STRUCTURES, "xyz_test.xyz")
 
-    path1 = os.path.join(STRUCTURES, "MIL53_small.xyz")
-    path2 = os.path.join(STRUCTURES, "nasty_cube.xyz")
-    path3 = os.path.join(STRUCTURES, "MeOH_Furan_end.xyz")
-    molecule1 = cc.Cartesian.read_xyz(path1)
-    molecule2 = cc.Cartesian.read_xyz(path2)
-    molecule3 = cc.Cartesian.read_xyz(path3)
+    try:
+        path1 = os.path.join(STRUCTURES, "MIL53_small.xyz")
+        path2 = os.path.join(STRUCTURES, "nasty_cube.xyz")
+        path3 = os.path.join(STRUCTURES, "MeOH_Furan_end.xyz")
+        molecule1 = cc.Cartesian.read_xyz(path1)
+        molecule2 = cc.Cartesian.read_xyz(path2)
+        molecule3 = cc.Cartesian.read_xyz(path3)
 
-    cartesian_list = [molecule1, molecule2, molecule3]
+        cartesian_list = [molecule1, molecule2, molecule3]
 
-    cc.xyz_functions.to_multiple_xyz(cartesian_list, output_path)
-    test_cartesian_list = cc.xyz_functions.read_multiple_xyz(output_path)
+        cc.xyz_functions.to_multiple_xyz(cartesian_list, output_path)
+        test_cartesian_list = cc.xyz_functions.read_multiple_xyz(output_path)
 
-    for ref, just_read in zip(cartesian_list, test_cartesian_list):
-        assert allclose(ref, just_read)
+        for ref, just_read in zip(cartesian_list, test_cartesian_list):
+            assert allclose(ref, just_read)
+    except Exception as e:
+        raise e
+    finally:
+        os.remove(output_path)


### PR DESCRIPTION
allow indexing with a query function such as
```python3
molecule.loc[lambda m: m.atom != "H", :]
```
to enable a fluent interface.

(This was already possible at runtime, but not encoded in the type system.)

---------------------------------------------------------------------

Clean up after new test.