### PR TITLE
fix small typing issue

### DIFF
--- a/src/chemcoord/typing.py
+++ b/src/chemcoord/typing.py
@@ -63,7 +63,7 @@ KwargDict: TypeAlias = dict[str, Any]
 
 AtomIdx = NewType("AtomIdx", int)
 
-Real: TypeAlias = int | float | np.integer | np.floating
+Real: TypeAlias = int | float | np.floating
 Integral: TypeAlias = int | np.integer
 
 


### PR DESCRIPTION
`np.integer` is not anymore a subtype of `Real`, `int` is still though.