### PR TITLE
pass on bond_dict explicitly instead of use_lookup

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -37,7 +37,6 @@ The possible settings and their defaults are:
    .. autosummary::
     :toctree: src_Defaults
 
-    ~Defaults.use_lookup
     ~Defaults.atomic_radius_data
     ~Defaults.viewer
     ~Defaults.list_viewer_file

--- a/docs/source/src_Defaults/chemcoord.configuration.Defaults.use_lookup.rst
+++ b/docs/source/src_Defaults/chemcoord.configuration.Defaults.use_lookup.rst
@@ -1,6 +1,0 @@
-chemcoord.configuration.Defaults.use\_lookup
-============================================
-
-.. currentmodule:: chemcoord.configuration
-
-.. autoattribute:: Defaults.use_lookup

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
@@ -659,7 +659,6 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         assert included_atoms_set.issubset(set(self.index)), (
             "The sliced Cartesian has to be a subset of the bigger frame"
         )
-        bond_dict = self.get_bonds()
         new_atoms: set[AtomIdx] = set()
         for atom in included_atoms_set:
             new_atoms = new_atoms | bond_dict[atom]

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
@@ -3,7 +3,7 @@ import itertools
 from collections import Counter, defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence, Set
 from itertools import product
-from typing import Any, Literal, cast, overload
+from typing import Any, Literal, TypeVar, cast, overload
 
 import numpy as np
 import pandas as pd
@@ -983,9 +983,9 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
                 fragments.append(fragment)  # type: ignore[arg-type]
         return fragments
 
-    def restrict_bond_dict(
-        self, bond_dict: Mapping[AtomIdx, set[AtomIdx]]
-    ) -> dict[AtomIdx, set[AtomIdx]]:
+    _T = TypeVar("_T", Set, SortedSet)
+
+    def restrict_bond_dict(self, bond_dict: Mapping[AtomIdx, _T]) -> dict[AtomIdx, _T]:
         """Restrict a bond dictionary to self.
 
         Args:

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_core.py
@@ -30,6 +30,7 @@ from chemcoord.typing import (
     ArithmeticOther,
     AtomIdx,
     Axes,
+    BondDict,
     Integral,
     Matrix,
     Real,
@@ -447,32 +448,9 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         | Callable[[Real], Real]
         | Mapping[str, Real]
         | None = None,
-        use_lookup: bool = False,
-        set_lookup: bool = True,
         atomic_radius_data_col: str | None = None,
     ) -> dict[AtomIdx, set[AtomIdx]]:
         """Return a dictionary representing the bonds.
-
-        .. warning:: This function is **not sideeffect free**, since it
-            assigns the output to a variable ``self._metadata['bond_dict']`` if
-            ``set_lookup`` is ``True`` (which is the default). This is
-            necessary for performance reasons.
-
-        ``.get_bonds()`` will use or not use a lookup
-        depending on ``use_lookup``. Greatly increases performance if
-        True, but could introduce bugs in certain situations.
-
-        Just imagine a situation where the :class:`~Cartesian` is
-        changed manually. If you apply lateron a method e.g.
-        :meth:`~get_zmat()` that makes use of :meth:`~get_bonds()`
-        the dictionary of the bonds
-        may not represent the actual situation anymore.
-
-        You have two possibilities to cope with this problem.
-        Either you just re-execute ``get_bonds`` on your specific instance,
-        or you change the ``internally_use_lookup`` option in the settings.
-        Please note that the internal use of the lookup variable
-        greatly improves performance.
 
         Args:
             modify_atom_data : If you want to change the van der
@@ -497,8 +475,6 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
                 If :python:`None`, it will be chosen slightly larger than twice
                 the maximum atom radius, which guarantees that no bond is missed because
                 of binning.
-            use_lookup (bool):
-            set_lookup (bool):
             self_bonding_allowed (bool):
             atomic_radius_data (str): Defines which column of
                 :attr:`constants.elements` is used. The default is
@@ -553,33 +529,14 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
                 for key in bond_dict
             }
 
-        if use_lookup:
-            bond_dict = self._metadata.get("bond_dict", complete_calculation())
-        else:
-            bond_dict = complete_calculation()
+        return complete_calculation()
 
-        if set_lookup:
-            self._metadata["bond_dict"] = bond_dict
-        return bond_dict
-
-    def _give_val_sorted_bond_dict(self, use_lookup: bool) -> dict[AtomIdx, SortedSet]:
-        def complete_calculation() -> dict[AtomIdx, SortedSet]:
-            bond_dict = self.get_bonds(use_lookup=use_lookup)
-            valency = dict(zip(self.index, self.add_data("valency")["valency"]))
-            val_bond_dict = {
-                key: SortedSet([i for i in bond_dict[key]], key=lambda x: -valency[x])
-                for key in bond_dict
-            }
-            return val_bond_dict
-
-        if use_lookup:
-            try:
-                val_bond_dict = self._metadata["val_bond_dict"]
-            except KeyError:
-                val_bond_dict = complete_calculation()
-        else:
-            val_bond_dict = complete_calculation()
-        self._metadata["val_bond_dict"] = val_bond_dict
+    def _sort_by_valency(self, bond_dict: BondDict) -> dict[AtomIdx, SortedSet]:
+        valency = dict(zip(self.index, self.add_data("valency")["valency"]))
+        val_bond_dict = {
+            key: SortedSet([i for i in bond_dict[key]], key=lambda x: -valency[x])
+            for key in bond_dict
+        }
         return val_bond_dict
 
     @overload
@@ -591,7 +548,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         give_only_index: Literal[False] = False,
         only_surface: bool = ...,
         exclude: set[AtomIdx] | None = ...,
-        use_lookup: bool | None = ...,
+        bond_dict: BondDict | None = ...,
     ) -> Self: ...
 
     @overload
@@ -603,7 +560,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         give_only_index: Literal[True],
         only_surface: bool = ...,
         exclude: set[AtomIdx] | None = ...,
-        use_lookup: bool | None = ...,
+        bond_dict: BondDict | None = ...,
     ) -> set[AtomIdx]: ...
 
     def get_coordination_sphere(
@@ -614,7 +571,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         give_only_index: bool = False,
         only_surface: bool = True,
         exclude: set[AtomIdx] | None = None,
-        use_lookup: bool | None = None,
+        bond_dict: BondDict | None = None,
     ) -> Self | set[AtomIdx]:
         """Return a Cartesian of atoms in the n-th coordination sphere.
 
@@ -631,17 +588,13 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
                 sphere.
             exclude (set): A set of indices that should be ignored
                 for the path finding.
-            use_lookup (bool): Use a lookup variable for
-                :meth:`~chemcoord.Cartesian.get_bonds`. The default is
-                specified in ``settings.defaults.use_lookup``
 
         Returns:
             A set of indices or a new Cartesian instance.
         """
-        if use_lookup is None:
-            use_lookup = settings.defaults.use_lookup
         exclude = set() if exclude is None else exclude
-        bond_dict = self.get_bonds(use_lookup=use_lookup)
+        if bond_dict is None:
+            bond_dict = self.get_bonds()
         i = index_of_atom
         if (n_sphere < 0) or (n_sphere < float("inf") and n_sphere != int(n_sphere)):
             raise ValueError(
@@ -678,7 +631,9 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             return self.loc[index_out - exclude]
 
     def _preserve_bonds(
-        self, sliced_cartesian: Self, use_lookup: bool | None = None
+        self,
+        sliced_cartesian: Self,
+        bond_dict: BondDict | None = None,
     ) -> Self:
         """Is called after cutting geometric shapes.
 
@@ -691,24 +646,23 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
 
         Args:
             sliced_frame (Cartesian):
-            use_lookup (bool): Use a lookup variable for
-                :meth:`~chemcoord.Cartesian.get_bonds`. The default is
-                specified in ``settings.defaults.use_lookup``
+            bond_dict : A bond dictionary computed via
+                :meth:`~chemcoord.Cartesian.get_bonds`.
 
         Returns:
             Cartesian:
         """
-        if use_lookup is None:
-            use_lookup = settings.defaults.use_lookup
+        if bond_dict is None:
+            bond_dict = self.get_bonds()
 
         included_atoms_set = set(sliced_cartesian.index)
         assert included_atoms_set.issubset(set(self.index)), (
             "The sliced Cartesian has to be a subset of the bigger frame"
         )
-        bond_dic = self.get_bonds(use_lookup=use_lookup)
+        bond_dict = self.get_bonds()
         new_atoms: set[AtomIdx] = set()
         for atom in included_atoms_set:
-            new_atoms = new_atoms | bond_dic[atom]
+            new_atoms = new_atoms | bond_dict[atom]
         new_atoms = new_atoms - included_atoms_set
         while not new_atoms == set():
             index_of_interest = new_atoms.pop()
@@ -718,7 +672,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
                 only_surface=False,
                 exclude=included_atoms_set,
                 give_only_index=True,
-                use_lookup=use_lookup,
+                bond_dict=bond_dict,
             )
             new_atoms = new_atoms - included_atoms_set
         molecule = self.loc[included_atoms_set, :]
@@ -981,43 +935,43 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
     @overload
     def fragmentate(
         self,
-        give_only_index: Literal[False] = False,
-        use_lookup: bool | None = ...,
+        give_only_index: Literal[False] = ...,
+        bond_dict: BondDict | None = ...,
     ) -> list[Self]: ...
 
     @overload
     def fragmentate(
-        self, give_only_index: Literal[True], use_lookup: bool | None = ...
+        self,
+        give_only_index: Literal[True],
+        bond_dict: BondDict | None = ...,
     ) -> list[set[AtomIdx]]: ...
 
     def fragmentate(
-        self, give_only_index: bool = False, use_lookup: bool | None = None
+        self,
+        give_only_index: bool = False,
+        bond_dict: BondDict | None = None,
     ) -> list[Self] | list[set[AtomIdx]]:
         """Get the indices of non bonded parts in the molecule.
 
         Args:
             give_only_index (bool): If ``True`` a set of indices is returned.
                 Otherwise a new Cartesian instance.
-            use_lookup (bool): Use a lookup variable for
+            bond_dict : A bond dictionary computed via
                 :meth:`~chemcoord.Cartesian.get_bonds`.
-            use_lookup (bool): Use a lookup variable for
-                :meth:`~chemcoord.Cartesian.get_bonds`. The default is
-                specified in ``settings.defaults.use_lookup``
 
         Returns:
             list: A list of sets of indices or new Cartesian instances.
         """
-        if use_lookup is None:
-            use_lookup = settings.defaults.use_lookup
+        if bond_dict is None:
+            bond_dict = self.get_bonds()
 
         fragments: list[set[AtomIdx]] | list[Self] = []
         pending = set(self.index)
-        self.get_bonds(use_lookup=use_lookup)
 
         while pending:
             index = self.get_coordination_sphere(
                 pending.pop(),
-                use_lookup=True,
+                bond_dict=bond_dict,
                 n_sphere=float("inf"),
                 only_surface=False,
                 give_only_index=True,
@@ -1027,15 +981,6 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
                 fragments.append(index)  # type: ignore[arg-type]
             else:
                 fragment = self.loc[index]
-                fragment._metadata["bond_dict"] = fragment.restrict_bond_dict(
-                    self._metadata["bond_dict"]
-                )
-                try:
-                    fragment._metadata["val_bond_dict"] = fragment.restrict_bond_dict(
-                        self._metadata["val_bond_dict"]
-                    )
-                except KeyError:
-                    pass
                 fragments.append(fragment)  # type: ignore[arg-type]
         return fragments
 
@@ -1058,7 +1003,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         self,
         list_of_indextuples: Sequence[tuple[AtomIdx, AtomIdx]],
         give_only_index: Literal[False] = False,
-        use_lookup: bool | None = None,
+        bond_dict: BondDict | None = None,
     ) -> Self: ...
 
     @overload
@@ -1066,14 +1011,14 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         self,
         list_of_indextuples: Sequence[tuple[AtomIdx, AtomIdx]],
         give_only_index: Literal[True],
-        use_lookup: bool | None = None,
+        bond_dict: BondDict | None = None,
     ) -> set[AtomIdx]: ...
 
     def get_fragment(
         self,
         list_of_indextuples: Sequence[tuple[AtomIdx, AtomIdx]],
         give_only_index: bool = False,
-        use_lookup: bool | None = None,
+        bond_dict: BondDict | None = None,
     ) -> Self | set[AtomIdx]:
         """Get the indices of the atoms in a fragment.
 
@@ -1087,15 +1032,14 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             list_of_indextuples (list):
             give_only_index (bool): If ``True`` a set of indices
                 is returned. Otherwise a new Cartesian instance.
-            use_lookup (bool): Use a lookup variable for
-                :meth:`~chemcoord.Cartesian.get_bonds`. The default is
-                specified in ``settings.defaults.use_lookup``
+            bond_dict : A bond dictionary computed via
+                :meth:`~chemcoord.Cartesian.get_bonds`.
 
         Returns:
             A set of indices or a new Cartesian instance.
         """
-        if use_lookup is None:
-            use_lookup = settings.defaults.use_lookup
+        if bond_dict is None:
+            bond_dict = self.get_bonds()
 
         exclude = [tuple[0] for tuple in list_of_indextuples]
 
@@ -1108,7 +1052,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             n_sphere=float("inf"),
             only_surface=False,
             give_only_index=True,
-            use_lookup=use_lookup,
+            bond_dict=bond_dict,
         )
         if give_only_index:
             return fragment_index
@@ -1118,23 +1062,19 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
     def get_without(
         self,
         fragments: Self | Sequence[Self],
-        use_lookup: bool | None = None,
+        bond_dict: BondDict | None = None,
     ) -> list[Self]:
         """Return self without the specified fragments.
 
         Args:
             fragments: Either a list of :class:`~chemcoord.Cartesian` or a
                 :class:`~chemcoord.Cartesian`.
-            use_lookup (bool): Use a lookup variable for
-                :meth:`~chemcoord.Cartesian.get_bonds`. The default is
-                specified in ``settings.defaults.use_lookup``
+            bond_dict : A bond dictionary computed via
+                :meth:`~chemcoord.Cartesian.get_bonds`.
 
         Returns:
             list: List containing :class:`~chemcoord.Cartesian`.
         """
-        if use_lookup is None:
-            use_lookup = settings.defaults.use_lookup
-
         if isinstance(fragments, Sequence):
             index_of_all_fragments = OrderedSet(fragments[0].index)
             for fragment in fragments[1:]:
@@ -1142,8 +1082,12 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
         else:
             index_of_all_fragments = fragments.index  # type: ignore[assignment]
         missing_part = self.loc[OrderedSet(self.index) - index_of_all_fragments]
+        if bond_dict is None:
+            bond_dict = missing_part.get_bonds()
+        else:
+            bond_dict = missing_part.restrict_bond_dict(bond_dict)
         return sorted(
-            missing_part.fragmentate(use_lookup=use_lookup), key=len, reverse=True
+            missing_part.fragmentate(bond_dict=bond_dict), key=len, reverse=True
         )
 
     @staticmethod
@@ -1376,7 +1320,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
             return None
 
     def partition_chem_env(
-        self, n_sphere: int = 4, use_lookup: bool | None = None
+        self, n_sphere: int = 4, bond_dict: BondDict | None = None
     ) -> dict[tuple[str, frozenset[tuple[str, int]]], set[AtomIdx]]:
         """This function partitions the molecule into subsets of the
         same chemical environment.
@@ -1410,9 +1354,8 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
 
         Args:
             n_sphere (int):
-            use_lookup (bool): Use a lookup variable for
-                :meth:`~chemcoord.Cartesian.get_bonds`. The default is
-                specified in ``settings.defaults.use_lookup``
+            bond_dict : A bond dictionary computed via
+                :meth:`~chemcoord.Cartesian.get_bonds`.
 
         Returns:
             dict: The output will look like this::
@@ -1422,8 +1365,8 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
                 A dictionary mapping from a chemical environment to
                 the set of indices of atoms in this environment.
         """
-        if use_lookup is None:
-            use_lookup = settings.defaults.use_lookup
+        if bond_dict is None:
+            bond_dict = self.get_bonds()
 
         def get_chem_env(
             self: Self, i: AtomIdx, n_sphere: float
@@ -1433,7 +1376,7 @@ class CartesianCore(PandasWrapper, GenericCore):  # noqa: PLW1641
                 n_sphere=n_sphere,
                 only_surface=False,
                 give_only_index=True,
-                use_lookup=use_lookup,
+                bond_dict=bond_dict,
             )
             env_index.remove(i)
             atoms = self.loc[env_index, "atom"]

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_get_zmat.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_get_zmat.py
@@ -321,7 +321,6 @@ class CartesianGetZmat(CartesianCore):
         c_table = full_table
         if perform_checks:
             c_table = self.correct_dihedral(c_table, sorted_bond_dict)
-            c_table = self.correct_dihedral(c_table, sorted_bond_dict)
             c_table = self.correct_absolute_refs(c_table)
         return c_table
 

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_get_zmat.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_get_zmat.py
@@ -229,14 +229,14 @@ class CartesianGetZmat(CartesianCore):
         """
         if bond_dict is None:
             bond_dict = self.get_bonds()
+        sorted_bond_dict = self._sort_by_valency(bond_dict)
 
         if fragment_list is not None:
             fragments = fragment_list
         else:
             fragments = sorted(
-                self.fragmentate(bond_dict=bond_dict), key=len, reverse=True
+                self.fragmentate(bond_dict=sorted_bond_dict), key=len, reverse=True
             )
-        sorted_bond_dict = self._sort_by_valency(bond_dict)
 
         def prepend_missing_parts_of_molecule(
             fragment_list: Sequence[Self | tuple[Self, DataFrame]],
@@ -260,12 +260,13 @@ class CartesianGetZmat(CartesianCore):
         if isinstance(fragments[0], tuple):
             fragment, references = fragments[0]
             full_table = fragment._get_frag_constr_table(
-                sorted_bond_dict=sorted_bond_dict, predefined_table=references
+                sorted_bond_dict=fragment.restrict_bond_dict(sorted_bond_dict),
+                predefined_table=references,
             )
         else:
             fragment = fragments[0]
             full_table = fragment._get_frag_constr_table(
-                sorted_bond_dict=sorted_bond_dict
+                sorted_bond_dict=fragment.restrict_bond_dict(sorted_bond_dict)
             )
 
         for specified in fragments[1:]:
@@ -280,7 +281,7 @@ class CartesianGetZmat(CartesianCore):
                     )
                 constr_table = fragment._get_frag_constr_table(
                     predefined_table=references,
-                    sorted_bond_dict=sorted_bond_dict,
+                    sorted_bond_dict=fragment.restrict_bond_dict(sorted_bond_dict),
                 )
             else:
                 fragment = specified

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
@@ -347,7 +347,6 @@ class CartesianIO(CartesianCore, GenericIO):
         cls,
         buf: ReadCsvBuffer[str] | PathLike,
         start_index: int = 0,
-        get_bonds: bool = True,
         nrows: int | None = None,
         engine: Literal["c", "python", "pyarrow", "python-fwf"] | None = None,
     ) -> Self:
@@ -366,7 +365,6 @@ class CartesianIO(CartesianCore, GenericIO):
                 By file-like object, we refer to objects with a read() method,
                 such as a file handler (e.g. via builtin open function) or StringIO.
             start_index (int):
-            get_bonds (bool):
             nrows (int): Number of rows of file to read.
                 Note that the first two rows are implicitly excluded.
             engine (str): Wrapper for the same argument of :func:`pandas.read_csv`.
@@ -391,8 +389,6 @@ class CartesianIO(CartesianCore, GenericIO):
         molecule = cls(frame)
         molecule.index = range(start_index, start_index + len(molecule))  # type: ignore[assignment]
 
-        if get_bonds:
-            molecule.get_bonds(use_lookup=False, set_lookup=True)
         return molecule
 
     @overload

--- a/src/chemcoord/_cartesian_coordinates/xyz_functions.py
+++ b/src/chemcoord/_cartesian_coordinates/xyz_functions.py
@@ -157,9 +157,7 @@ def to_multiple_xyz(
         return output
 
 
-def read_multiple_xyz(
-    inputfile: PathLike, start_index: int = 0, get_bonds: bool = True
-) -> list[Cartesian]:
+def read_multiple_xyz(inputfile: PathLike, start_index: int = 0) -> list[Cartesian]:
     """Read a multiple-xyz file.
 
     Args:
@@ -182,7 +180,6 @@ def read_multiple_xyz(
                         "".join(strings[current_line : current_line + molecule_len + 2])
                     ),
                     start_index=start_index,
-                    get_bonds=get_bonds,
                     nrows=molecule_len,
                     engine="python",
                 )
@@ -286,9 +283,7 @@ def write_molden(*args, **kwargs):  # type: ignore[no-untyped-def]
     return to_molden(*args, **kwargs)
 
 
-def read_molden(
-    inputfile: PathLike, start_index: int = 0, get_bonds: bool = True
-) -> list[Cartesian]:
+def read_molden(inputfile: PathLike, start_index: int = 0) -> list[Cartesian]:
     """Read a molden file.
 
     Args:
@@ -329,7 +324,6 @@ def read_molden(
             cartesian = Cartesian.read_xyz(
                 f,
                 start_index=start_index,
-                get_bonds=get_bonds,
                 nrows=number_of_atoms,
                 engine="python",
             )

--- a/src/chemcoord/configuration.py
+++ b/src/chemcoord/configuration.py
@@ -12,7 +12,6 @@ DEFAULT_RC_PATH: Final = Path("~/.chemcoord.yml")
 
 @define(hash=True, kw_only=True)
 class Defaults:
-    use_lookup: bool = False
     #: Which atomic radius data to use.
     atomic_radius_data: str = "atomic_radius_cc"
     #: Which molecular viewer to use.

--- a/src/chemcoord/typing.py
+++ b/src/chemcoord/typing.py
@@ -10,7 +10,7 @@ i.e. the type is mostly useful to document intent to the developer.
 """
 
 import os
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence, Set
 from typing import Any, NewType, TypeAlias, TypeVar
 
 import numpy as np
@@ -62,6 +62,7 @@ KwargDict: TypeAlias = dict[str, Any]
 
 
 AtomIdx = NewType("AtomIdx", int)
+BondDict: TypeAlias = Mapping[AtomIdx, Set[AtomIdx]]
 
 Real: TypeAlias = int | float | np.floating
 Integral: TypeAlias = int | np.integer

--- a/tests/cartesian_coordinates/Cartesian/test_core.py
+++ b/tests/cartesian_coordinates/Cartesian/test_core.py
@@ -185,9 +185,6 @@ def test_assignment():
 
 def test_get_bonds():
     assert bond_dict == molecule.get_bonds()
-    molecule._metadata["bond_dict"][56].add(4)
-    assert not (bond_dict == molecule.get_bonds(use_lookup=True))
-    assert bond_dict == molecule.get_bonds()
     modified_expected = {
         1: {51},
         3: {6, 55, 56},


### PR DESCRIPTION
- got rid of `use_lookup` and pass on `bond_dict` explicitly instead.

closes #143 