### PR TITLE
fixed from_ase_atoms method

### DIFF
--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
@@ -616,7 +616,7 @@ class CartesianIO(CartesianCore, GenericIO):
             """
             return cls.set_atom_coords(
                 atoms=atoms.get_chemical_symbols(), coords=atoms.positions
-            )  # type: ignore[call-arg]
+            )
 
     if pyscf is not None:
 

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
@@ -614,7 +614,7 @@ class CartesianIO(CartesianCore, GenericIO):
             Returns:
                 Cartesian:
             """
-            return cls(atoms=atoms.get_chemical_symbols(), coords=atoms.positions)  # type: ignore[call-arg]
+            return cls.set_atom_coords(atoms=atoms.get_chemical_symbols(), coords=atoms.positions)  # type: ignore[call-arg]
 
     if pyscf is not None:
 

--- a/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
+++ b/src/chemcoord/_cartesian_coordinates/_cartesian_class_io.py
@@ -614,7 +614,9 @@ class CartesianIO(CartesianCore, GenericIO):
             Returns:
                 Cartesian:
             """
-            return cls.set_atom_coords(atoms=atoms.get_chemical_symbols(), coords=atoms.positions)  # type: ignore[call-arg]
+            return cls.set_atom_coords(
+                atoms=atoms.get_chemical_symbols(), coords=atoms.positions
+            )  # type: ignore[call-arg]
 
     if pyscf is not None:
 


### PR DESCRIPTION
from_ase_atoms from CartesianIO was using an incorrect constructor, so was updated to align with the other constructing methods.