### PR TITLE
temporary fix for #162 by forcing pandas < 3.0.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,7 +64,7 @@ extensions = [
 intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "ase": ("https://ase-lib.org/", None),
-    "pandas": ("http://pandas.pydata.org/pandas-docs/stable/", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/version/2.3/", None),
     "sympy": ("https://docs.sympy.org/latest/", None),
     "pymatgen": ("https://pymatgen.org/", None),
     "python": ("https://docs.python.org/3", None),

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ EMAIL = "oskar.weser@gmail.com"
 URL = "https://github.com/mcocdawc/chemcoord"
 INSTALL_REQUIRES = [
     "numpy>=1.0",
-    "pandas>=1.0",
+    "pandas>=1.0,<3.0.0",
     "numba>=0.35",
     "sortedcontainers",
     "sympy",


### PR DESCRIPTION
A temporary fix for #162 by not allowing the latest pandas 3.0.0. This should temporarily allow dependent project (QuEmb) to easily continue CI tests.